### PR TITLE
Update Grafana VM config to match live deployment

### DIFF
--- a/fly/grafana/fly.toml
+++ b/fly/grafana/fly.toml
@@ -62,8 +62,8 @@ primary_region = "ord"
 
 [[vm]]
   cpu_kind = "shared"
-  cpus = 2
-  memory_mb = 1024
+  cpus = 1
+  memory_mb = 512
 
 [mounts]
   source = "grafana_data"


### PR DESCRIPTION
## Summary

Updates `fly/grafana/fly.toml` to match the current live production configuration.

## Changes

- **CPUs**: Reduced from 2 to 1
- **Memory**: Reduced from 1024MB to 512MB

## Rationale

The Grafana app was manually scaled down via the Fly.io dashboard to `shared-cpu-1x (512MB)` to optimize costs. This PR updates the repository configuration to match, ensuring future deployments maintain the optimized resource allocation.

## Impact

- ✅ **Prevents accidental resource increases** on future deployments
- ✅ **Locks in cost savings** of ~$7.76/month (~$93/year)
- ✅ **Ensures fly.toml matches production** for consistency

## Verification

Current live configuration verified via `flyctl machine status`:
- **linknode-web**: 1 CPU, 256MB ✅ (already matches)
- **linknode-eagle-monitor**: 1 CPU, 256MB ✅ (already matches)
- **linknode-grafana**: 1 CPU, 512MB ✅ (updated in this PR)
- **linknode-influxdb**: 1 CPU, 256MB ✅ (already matches)

## Testing

No code changes - configuration only. Current production system has been running with these settings successfully.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>