### PR TITLE
Add in-process data staleness monitoring to eagle-monitor

### DIFF
--- a/fly/eagle-monitor/Dockerfile
+++ b/fly/eagle-monitor/Dockerfile
@@ -10,6 +10,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application
 COPY app.py .
 COPY security_monitor.py .
+COPY monitor_data_staleness.py .
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1

--- a/fly/eagle-monitor/app.py
+++ b/fly/eagle-monitor/app.py
@@ -2,6 +2,7 @@
 """
 Eagle-200 XML Monitor for InfluxDB
 Receives XML POST data from Eagle-200 energy monitor and stores in InfluxDB
+Includes data staleness monitoring with Slack alerts
 """
 
 import os
@@ -17,6 +18,9 @@ from functools import wraps
 import hashlib
 import base64
 from security_monitor import security_monitor, require_api_key_with_monitoring
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from monitor_data_staleness import DataStalenessMonitor
 
 # Configure logging
 logging.basicConfig(
@@ -102,6 +106,15 @@ stats = {
     'packets_today': 0,
     'packets_today_date': datetime.now(timezone.utc).strftime('%Y-%m-%d')
 }
+
+# Initialize data staleness monitor
+monitor = DataStalenessMonitor(
+    slack_webhook=os.getenv('SLACK_WEBHOOK_URL'),
+    stale_threshold_minutes=int(os.getenv('STALE_THRESHOLD_MINUTES', '5'))
+)
+
+# Background scheduler for monitoring
+scheduler = None
 
 # Initialize InfluxDB client
 influx_client = None
@@ -221,6 +234,34 @@ def init_influxdb():
     except Exception as e:
         logger.error(f"Failed to connect to InfluxDB: {e}")
         return False
+
+def start_data_monitor():
+    """Start the data staleness monitoring background task"""
+    global scheduler
+
+    if scheduler is None:
+        scheduler = BackgroundScheduler()
+
+        # Add job to check data freshness every 5 minutes
+        scheduler.add_job(
+            check_data_health,
+            IntervalTrigger(minutes=5),
+            id='data_staleness_check',
+            name='Check data staleness',
+            replace_existing=True
+        )
+
+        scheduler.start()
+        logger.info("Data staleness monitor started (checks every 5 minutes)")
+
+def check_data_health():
+    """Background job to check if data is still arriving"""
+    try:
+        current_status, transitioned = monitor.check_data_freshness(stats)
+        if transitioned:
+            logger.info(f"Data health status changed to: {current_status}")
+    except Exception as e:
+        logger.error(f"Error in data health check: {e}")
 
 def parse_eagle_xml(xml_data):
     """Parse Eagle-200 XML data"""
@@ -733,8 +774,8 @@ def get_security_stats():
     if not admin_key or provided_key != admin_key:
         return jsonify({'error': 'Admin access required'}), 403
     
-    stats = security_monitor.get_security_stats()
-    return jsonify(stats), 200
+    stats_result = security_monitor.get_security_stats()
+    return jsonify(stats_result), 200
 
 if __name__ == '__main__':
     # Wait for InfluxDB to be ready
@@ -748,7 +789,10 @@ if __name__ == '__main__':
     
     if not influx_client:
         logger.error("Failed to connect to InfluxDB after 30 retries")
-    
+
+    # Start the data staleness monitor
+    start_data_monitor()
+
     # Run Flask app
     port = int(os.getenv('PORT', '5000'))
     app.run(host='0.0.0.0', port=port, debug=False)

--- a/fly/eagle-monitor/monitor_data_staleness.py
+++ b/fly/eagle-monitor/monitor_data_staleness.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Data Staleness Monitor for Eagle-200 Monitor
+Detects when data stops arriving from the power meter and sends Slack alerts
+on state transitions (healthy <-> unhealthy).
+"""
+
+import os
+import logging
+import json
+from datetime import datetime, timezone, timedelta
+import requests
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class DataStalenessMonitor:
+    """Monitor data freshness and track state transitions"""
+
+    def __init__(self, state_file=None, slack_webhook=None, stale_threshold_minutes=5):
+        """
+        Initialize the monitor.
+
+        Args:
+            state_file: Path to JSON file for persisting state (default: /tmp/eagle_monitor_state.json)
+            slack_webhook: Slack webhook URL for alerts
+            stale_threshold_minutes: Consider data stale if older than this many minutes
+        """
+        self.state_file = state_file or os.getenv('MONITOR_STATE_FILE', '/tmp/eagle_monitor_state.json')
+        self.slack_webhook = slack_webhook or os.getenv('SLACK_WEBHOOK_URL')
+        self.stale_threshold_minutes = stale_threshold_minutes
+        self.previous_status = self._load_state()
+
+        logger.info(f"DataStalenessMonitor initialized with threshold: {stale_threshold_minutes} minutes")
+
+    def _load_state(self):
+        """Load previous state from file"""
+        try:
+            if os.path.exists(self.state_file):
+                with open(self.state_file, 'r') as f:
+                    data = json.load(f)
+                    return data.get('status', 'healthy')
+        except Exception as e:
+            logger.warning(f"Failed to load state from {self.state_file}: {e}")
+        return 'healthy'
+
+    def _save_state(self, status):
+        """Save state to file"""
+        try:
+            state_data = {
+                'status': status,
+                'timestamp': datetime.now(timezone.utc).isoformat()
+            }
+            os.makedirs(os.path.dirname(self.state_file) or '.', exist_ok=True)
+            with open(self.state_file, 'w') as f:
+                json.dump(state_data, f)
+            logger.debug(f"State saved: {status}")
+        except Exception as e:
+            logger.error(f"Failed to save state to {self.state_file}: {e}")
+
+    def _send_slack_alert(self, message, emoji='⚠️'):
+        """Send message to Slack"""
+        if not self.slack_webhook:
+            logger.warning("No Slack webhook configured, skipping alert")
+            return False
+
+        try:
+            payload = {
+                'text': f"{emoji} *Linknode Power Monitor Alert*\n{message}\nTime: {datetime.now(timezone.utc).isoformat()}"
+            }
+            response = requests.post(self.slack_webhook, json=payload, timeout=10)
+            response.raise_for_status()
+            logger.info(f"Slack alert sent successfully")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to send Slack alert: {e}")
+            return False
+
+    def check_data_freshness(self, stats_dict):
+        """
+        Check if data is fresh and handle state transitions.
+
+        Args:
+            stats_dict: The stats dictionary from the Flask app
+
+        Returns:
+            tuple: (current_status, transitioned) - transitioned is True if state changed
+        """
+        # Determine current status
+        current_status = self._evaluate_health(stats_dict)
+        transitioned = current_status != self.previous_status
+
+        if transitioned:
+            logger.warning(f"Status transition: {self.previous_status} → {current_status}")
+
+            if current_status == 'unhealthy':
+                # Going unhealthy
+                reason = self._get_failure_reason(stats_dict)
+                message = f"Data is not arriving from power meter!\n{reason}"
+                self._send_slack_alert(message, emoji='🚨')
+            else:
+                # Going healthy
+                current_power = stats_dict.get('last_power_reading', 'N/A')
+                last_update = stats_dict.get('last_data_received', 'N/A')
+                message = f"Power meter is back online!\nCurrent: {current_power}W\nLast update: {last_update}"
+                self._send_slack_alert(message, emoji='✅')
+
+            # Save new state
+            self._save_state(current_status)
+            self.previous_status = current_status
+
+        return current_status, transitioned
+
+    def _evaluate_health(self, stats_dict):
+        """
+        Evaluate system health based on stats.
+
+        Returns:
+            'healthy' or 'unhealthy'
+        """
+        # Check if we have a last_data_received timestamp
+        last_update = stats_dict.get('last_data_received')
+        if not last_update:
+            return 'unhealthy'
+
+        try:
+            # Parse the ISO format timestamp
+            if isinstance(last_update, str):
+                # Handle ISO format with or without 'Z'
+                if last_update.endswith('Z'):
+                    last_update = last_update.rstrip('Z') + '+00:00'
+                last_update_dt = datetime.fromisoformat(last_update)
+            else:
+                last_update_dt = last_update
+
+            # Calculate age
+            now = datetime.now(timezone.utc)
+            age = now - last_update_dt
+            age_minutes = age.total_seconds() / 60
+
+            # Check if data is stale
+            if age_minutes > self.stale_threshold_minutes:
+                logger.warning(f"Data is stale: {age_minutes:.1f} minutes old (threshold: {self.stale_threshold_minutes})")
+                return 'unhealthy'
+
+            # Check if last power reading exists and is non-zero
+            last_power = stats_dict.get('last_power_reading')
+            if last_power is None or last_power == 0:
+                logger.warning(f"Invalid power reading: {last_power}")
+                return 'unhealthy'
+
+            return 'healthy'
+
+        except Exception as e:
+            logger.error(f"Error evaluating health: {e}")
+            return 'unhealthy'
+
+    def _get_failure_reason(self, stats_dict):
+        """Get human-readable reason for failure"""
+        last_update = stats_dict.get('last_data_received')
+        if not last_update:
+            return "No data received yet"
+
+        try:
+            if isinstance(last_update, str):
+                if last_update.endswith('Z'):
+                    last_update = last_update.rstrip('Z') + '+00:00'
+                last_update_dt = datetime.fromisoformat(last_update)
+            else:
+                last_update_dt = last_update
+
+            now = datetime.now(timezone.utc)
+            age = now - last_update_dt
+            age_minutes = age.total_seconds() / 60
+
+            if age_minutes > self.stale_threshold_minutes:
+                return f"Last data received {age_minutes:.1f} minutes ago (threshold: {self.stale_threshold_minutes} minutes)"
+
+            last_power = stats_dict.get('last_power_reading')
+            if last_power is None or last_power == 0:
+                return f"Invalid power reading: {last_power}W"
+
+            return "Unknown error"
+        except Exception as e:
+            return f"Error determining reason: {e}"

--- a/fly/eagle-monitor/requirements.txt
+++ b/fly/eagle-monitor/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.0
 Flask-Cors==4.0.0
 influxdb-client==1.38.0
 Werkzeug==3.0.1
+APScheduler==3.10.4
+requests==2.31.0

--- a/fly/eagle-monitor/test_monitor_data_staleness.py
+++ b/fly/eagle-monitor/test_monitor_data_staleness.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Test suite for DataStalenessMonitor
+Tests state transitions and Slack alert behavior
+"""
+
+import unittest
+import json
+import os
+import tempfile
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+import sys
+
+# Import the monitor module
+from monitor_data_staleness import DataStalenessMonitor
+
+
+class TestDataStalenessMonitor(unittest.TestCase):
+    """Test the data staleness monitoring logic"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.state_file = os.path.join(self.temp_dir, 'test_state.json')
+
+        # Create monitor without Slack webhook for testing
+        self.monitor = DataStalenessMonitor(
+            state_file=self.state_file,
+            slack_webhook=None,  # Disable Slack for unit tests
+            stale_threshold_minutes=5
+        )
+
+    def tearDown(self):
+        """Clean up test files"""
+        if os.path.exists(self.state_file):
+            os.remove(self.state_file)
+        os.rmdir(self.temp_dir)
+
+    def test_healthy_system(self):
+        """Test that a system with recent data is healthy"""
+        now = datetime.now(timezone.utc)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        status = self.monitor._evaluate_health(stats)
+        self.assertEqual(status, 'healthy')
+
+    def test_stale_data_is_unhealthy(self):
+        """Test that stale data triggers unhealthy status"""
+        # Data from 10 minutes ago
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        stats = {
+            'last_data_received': old_time.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        status = self.monitor._evaluate_health(stats)
+        self.assertEqual(status, 'unhealthy')
+
+    def test_zero_power_is_unhealthy(self):
+        """Test that zero power reading triggers unhealthy status"""
+        now = datetime.now(timezone.utc)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 0
+        }
+
+        status = self.monitor._evaluate_health(stats)
+        self.assertEqual(status, 'unhealthy')
+
+    def test_missing_power_reading_is_unhealthy(self):
+        """Test that missing power reading triggers unhealthy status"""
+        now = datetime.now(timezone.utc)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': None
+        }
+
+        status = self.monitor._evaluate_health(stats)
+        self.assertEqual(status, 'unhealthy')
+
+    def test_state_transition_healthy_to_unhealthy(self):
+        """Test transition from healthy to unhealthy"""
+        # Start with healthy
+        now = datetime.now(timezone.utc)
+        healthy_stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        # Verify we start healthy
+        self.assertEqual(self.monitor.previous_status, 'healthy')
+
+        # Transition to unhealthy (old data)
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        unhealthy_stats = {
+            'last_data_received': old_time.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        status, transitioned = self.monitor.check_data_freshness(unhealthy_stats)
+        self.assertEqual(status, 'unhealthy')
+        self.assertTrue(transitioned)
+
+        # Verify state was saved
+        self.assertEqual(self.monitor.previous_status, 'unhealthy')
+
+    def test_state_transition_unhealthy_to_healthy(self):
+        """Test transition from unhealthy to healthy"""
+        # Manually set to unhealthy state
+        self.monitor.previous_status = 'unhealthy'
+
+        # Now provide healthy stats
+        now = datetime.now(timezone.utc)
+        healthy_stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        status, transitioned = self.monitor.check_data_freshness(healthy_stats)
+        self.assertEqual(status, 'healthy')
+        self.assertTrue(transitioned)
+        self.assertEqual(self.monitor.previous_status, 'healthy')
+
+    def test_no_transition_healthy_to_healthy(self):
+        """Test that staying healthy doesn't trigger transition"""
+        now = datetime.now(timezone.utc)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        # First call
+        status1, transitioned1 = self.monitor.check_data_freshness(stats)
+        self.assertEqual(status1, 'healthy')
+        self.assertFalse(transitioned1)  # Initial is not a "transition"
+
+        # Second call with same healthy state
+        status2, transitioned2 = self.monitor.check_data_freshness(stats)
+        self.assertEqual(status2, 'healthy')
+        self.assertFalse(transitioned2)  # No transition
+
+    def test_state_persistence(self):
+        """Test that state is saved and loaded from file"""
+        # Create first monitor and set it to unhealthy
+        now = datetime.now(timezone.utc) - timedelta(minutes=10)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        monitor1 = DataStalenessMonitor(state_file=self.state_file)
+        monitor1.check_data_freshness(stats)
+        self.assertEqual(monitor1.previous_status, 'unhealthy')
+
+        # Create new monitor from same state file
+        monitor2 = DataStalenessMonitor(state_file=self.state_file)
+        self.assertEqual(monitor2.previous_status, 'unhealthy')
+
+    def test_iso_timestamp_parsing_with_z(self):
+        """Test parsing ISO timestamps with Z suffix"""
+        # Timestamp with Z suffix
+        now_str = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        stats = {
+            'last_data_received': now_str,
+            'last_power_reading': 422.0
+        }
+
+        status = self.monitor._evaluate_health(stats)
+        self.assertEqual(status, 'healthy')
+
+    @patch('monitor_data_staleness.requests.post')
+    def test_slack_alert_on_unhealthy_transition(self, mock_post):
+        """Test that Slack alert is sent on unhealthy transition"""
+        # Create monitor with Slack webhook
+        monitor = DataStalenessMonitor(
+            state_file=self.state_file,
+            slack_webhook='https://hooks.slack.com/services/TEST/WEBHOOK',
+            stale_threshold_minutes=5
+        )
+
+        # Mock the POST request
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        # Transition to unhealthy
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        stats = {
+            'last_data_received': old_time.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        monitor.check_data_freshness(stats)
+
+        # Verify Slack was called
+        self.assertTrue(mock_post.called)
+
+        # Verify the alert contains key information
+        call_args = mock_post.call_args
+        payload = call_args[1]['json']
+        self.assertIn('Linknode Power Monitor Alert', payload['text'])
+        self.assertIn('Data is not arriving', payload['text'])
+
+    @patch('monitor_data_staleness.requests.post')
+    def test_slack_alert_on_healthy_transition(self, mock_post):
+        """Test that Slack recovery alert is sent on healthy transition"""
+        # Create monitor with Slack webhook
+        monitor = DataStalenessMonitor(
+            state_file=self.state_file,
+            slack_webhook='https://hooks.slack.com/services/TEST/WEBHOOK',
+            stale_threshold_minutes=5
+        )
+
+        # Manually set to unhealthy
+        monitor.previous_status = 'unhealthy'
+
+        # Mock the POST request
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        # Transition to healthy
+        now = datetime.now(timezone.utc)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        monitor.check_data_freshness(stats)
+
+        # Verify Slack was called
+        self.assertTrue(mock_post.called)
+
+        # Verify the alert contains recovery message
+        call_args = mock_post.call_args
+        payload = call_args[1]['json']
+        self.assertIn('back online', payload['text'])
+        self.assertIn('✅', payload['text'])
+
+    def test_failure_reason_stale_data(self):
+        """Test failure reason for stale data"""
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=10)
+        stats = {
+            'last_data_received': old_time.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        reason = self.monitor._get_failure_reason(stats)
+        self.assertIn('minutes ago', reason)
+        self.assertIn('threshold', reason)
+
+    def test_failure_reason_zero_power(self):
+        """Test failure reason for zero power"""
+        now = datetime.now(timezone.utc)
+        stats = {
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 0
+        }
+
+        reason = self.monitor._get_failure_reason(stats)
+        self.assertIn('Invalid power reading', reason)
+
+    def test_custom_stale_threshold(self):
+        """Test with custom stale threshold"""
+        monitor = DataStalenessMonitor(
+            state_file=self.state_file,
+            stale_threshold_minutes=2  # Custom 2-minute threshold
+        )
+
+        # Data from 3 minutes ago should be stale
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=3)
+        stats = {
+            'last_data_received': old_time.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        status = monitor._evaluate_health(stats)
+        self.assertEqual(status, 'unhealthy')
+
+        # But data from 1 minute ago should be healthy
+        recent_time = datetime.now(timezone.utc) - timedelta(minutes=1)
+        stats = {
+            'last_data_received': recent_time.isoformat(),
+            'last_power_reading': 422.0
+        }
+
+        status = monitor._evaluate_health(stats)
+        self.assertEqual(status, 'healthy')
+
+
+class TestIntegrationWithFlaskStats(unittest.TestCase):
+    """Integration tests with actual Flask stats format"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.state_file = os.path.join(self.temp_dir, 'test_state.json')
+        self.monitor = DataStalenessMonitor(
+            state_file=self.state_file,
+            slack_webhook=None,
+            stale_threshold_minutes=5
+        )
+
+    def tearDown(self):
+        """Clean up test files"""
+        if os.path.exists(self.state_file):
+            os.remove(self.state_file)
+        os.rmdir(self.temp_dir)
+
+    def test_with_flask_stats_format(self):
+        """Test with actual Flask stats dictionary format"""
+        now = datetime.now(timezone.utc)
+        flask_stats = {
+            'total_requests': 100,
+            'successful_writes': 98,
+            'failed_writes': 2,
+            'filtered_requests': 5,
+            'last_data_received': now.isoformat(),
+            'last_power_reading': 422.0,
+            'packet_interval_ms': 4612,
+            'packets_today': 100,
+            'packets_today_date': now.strftime('%Y-%m-%d')
+        }
+
+        status, transitioned = self.monitor.check_data_freshness(flask_stats)
+        self.assertEqual(status, 'healthy')
+
+    def test_with_missing_last_data_received(self):
+        """Test behavior when last_data_received is None (app just started)"""
+        flask_stats = {
+            'total_requests': 0,
+            'successful_writes': 0,
+            'failed_writes': 0,
+            'last_data_received': None,
+            'last_power_reading': None,
+        }
+
+        status = self.monitor._evaluate_health(flask_stats)
+        self.assertEqual(status, 'unhealthy')
+
+
+def run_tests():
+    """Run all tests with detailed output"""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+
+    # Add all test cases
+    suite.addTests(loader.loadTestsFromTestCase(TestDataStalenessMonitor))
+    suite.addTests(loader.loadTestsFromTestCase(TestIntegrationWithFlaskStats))
+
+    # Run with verbose output
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    return result.wasSuccessful()
+
+
+if __name__ == '__main__':
+    success = run_tests()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

Moves Linknode power-feed monitoring **into** the deployed `linknode-eagle-monitor` service, retiring the external workstation (Cowork Dispatch) monitor. The service now self-monitors: a background job checks whether Eagle data is still arriving and posts to Slack **only on healthy↔unhealthy transitions**.

Why in-process: the service runs as a single Flask process (`CMD ["python", "app.py"]`, no gunicorn workers), so a `BackgroundScheduler` fires exactly once — no duplicate alerts. The monitor reads the live in-memory `stats` dict directly, so it can check **data age**, which fixes the old monitor's blind spot (it only flagged `0W`/null, and `/api/stats.current_power` keeps returning the last good wattage when the feed freezes, so a stalled-but-nonzero feed was never caught).

## Changes (all additive to existing function)
- **`monitor_data_staleness.py`** (new): `DataStalenessMonitor` — age-based staleness check, file-backed state, transition-only Slack alerts.
- **`app.py`**: import + initialize the monitor, start a 5-minute `BackgroundScheduler` job in `__main__`. Existing routes/handlers unchanged. Also renamed a shadowing local `stats` in `get_security_stats` so it no longer masks the module-global `stats` the monitor now reads (behavioral no-op).
- **`requirements.txt`**: add `APScheduler==3.10.4`, `requests==2.31.0`.
- **`Dockerfile`**: `COPY monitor_data_staleness.py .` (required, or the app fails to import at boot).
- **`test_monitor_data_staleness.py`** (new): 16 unit tests, all passing.

## Configuration (set before/at deploy)
- `SLACK_WEBHOOK_URL` (**required**) — `fly secrets set SLACK_WEBHOOK_URL='https://hooks.slack.com/...'`. Recommend **rotating** the webhook, since the old value lived in plaintext in the workstation skill.
- `STALE_THRESHOLD_MINUTES` (optional, default `5`).

Detection latency ≈ threshold + 5-min check interval (~10 min worst case), vs. the old hourly external check. State persists to `/tmp` (default `MONITOR_STATE_FILE`); it survives in-process restarts but resets to "healthy" on a full redeploy — worst case one duplicate alert if redeployed while down.

## Test plan
- [x] `python -m py_compile app.py monitor_data_staleness.py test_monitor_data_staleness.py`
- [x] `python test_monitor_data_staleness.py` -> 16/16 pass
- [ ] `fly secrets set SLACK_WEBHOOK_URL='...'` then `fly deploy`
- [ ] `fly logs | grep "Data staleness monitor started"`
- [ ] Interrupt Eagle feed > threshold -> expect alert; restore -> expect recovery message
- [ ] Confirm `/eagle`, `/api/stats`, `/health` still behave as before

After verifying alerts fire from the service, decommission the workstation Cowork monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)