### PR TITLE
Fix Eagle timestamp decoding (Zigbee epoch) and empty-timestamp 400s

### DIFF
--- a/fly/eagle-monitor/app.py
+++ b/fly/eagle-monitor/app.py
@@ -263,6 +263,10 @@ def check_data_health():
     except Exception as e:
         logger.error(f"Error in data health check: {e}")
 
+# Eagle/Zigbee Smart Energy timestamps count seconds from 2000-01-01 UTC,
+# not the Unix epoch (1970-01-01). This is the gap between the two.
+ZIGBEE_EPOCH_OFFSET = 946684800  # seconds from 1970-01-01 to 2000-01-01 UTC
+
 def parse_eagle_xml(xml_data):
     """Parse Eagle-200 XML data"""
     try:
@@ -272,18 +276,16 @@ def parse_eagle_xml(xml_data):
         device_mac = root.findtext('.//DeviceMacId', '').replace('0x', '')
         meter_mac = root.findtext('.//MeterMacId', '').replace('0x', '')
         timestamp = root.findtext('.//TimeStamp', '')
-        
-        # Parse timestamp (Eagle sends as hex seconds since epoch)
-        if timestamp.startswith('0x'):
-            timestamp_int = int(timestamp, 16)
-        else:
-            timestamp_int = int(timestamp)
-        
-        # Convert to datetime
-        dt = datetime.fromtimestamp(timestamp_int, tz=timezone.utc)
-        
-        # Check if timestamp is reasonable (not more than 1 year in the past or future)
         now = datetime.now(timezone.utc)
+
+        # Decode the Zigbee-epoch timestamp; missing/non-numeric values fall back to now.
+        try:
+            timestamp_int = int(timestamp, 16) if timestamp.startswith('0x') else int(timestamp)
+            dt = datetime.fromtimestamp(timestamp_int + ZIGBEE_EPOCH_OFFSET, tz=timezone.utc)
+        except (ValueError, TypeError, OSError, OverflowError):
+            dt = now
+
+        # Safety net for genuinely implausible timestamps (more than a year off).
         one_year = 365 * 24 * 60 * 60  # seconds
         if abs((now - dt).total_seconds()) > one_year:
             logger.warning(f"Unreasonable timestamp from Eagle: {dt}, using current time instead")


### PR DESCRIPTION
## Summary

Fixes two pre-existing log issues in the Eagle XML ingestion path (surfaced while verifying the data-staleness monitor). Both trace to the same timestamp-parsing block in `parse_eagle_xml`.

### 1. Wrong epoch → every reading decoded ~30 years early
Eagle `TimeStamp` values are **seconds since 2000-01-01 UTC** (the Zigbee Smart Energy epoch), but the parser decoded them as the **Unix epoch (1970)**. The 30-year gap made 2026 readings land as **1996**, which tripped the ">1 year off" safety net on essentially every packet:
```
WARNING - Unreasonable timestamp from Eagle: 1996-05-23 07:32:02+00:00, using current time instead
```
Adding the `946684800`-second offset makes timestamps correct, so the warning stops firing and points are stored at the Eagle's actual reading time instead of receipt time.

### 2. Empty/non-numeric TimeStamp → HTTP 400
Packets with an empty `<TimeStamp>` hit `int('')`, which raised and returned 400:
```
ERROR - Error parsing XML: invalid literal for int() with base 10: ''
"POST /eagle HTTP/1.1" 400
```
The parse is now wrapped in `try/except`; such packets fall back to receipt time and are processed normally rather than rejected.

The existing >1-year safety net is retained, so this change is **fail-safe**: if the epoch assumption were ever wrong for some packet, it still falls back to "now" — the prior behavior. No regression possible.

## Verification
Reproduced the exact bug and confirmed the fix locally:
```
eagle sends   : 0x31a41635
OLD decode    : 1996-05-23T07:39:33+00:00   (matches production logs)
NEW decode    : 2026-05-23T07:39:33+00:00   (correct)
empty TimeStamp -> falls back to now (no 400)
```
- [x] `python -m py_compile app.py`
- [x] Epoch round-trip + empty-timestamp fallback validated
- [ ] After deploy: `fly logs` should no longer show "Unreasonable timestamp" or the empty-TimeStamp 400s

## Notes
Out of scope (pre-existing, not addressed here): `/api/stats` is unauthenticated because `EAGLE_API_KEY` isn't set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)