### PR TITLE
Quiet auth-disabled log and surface unhandled message payloads

### DIFF
--- a/fly/eagle-monitor/app.py
+++ b/fly/eagle-monitor/app.py
@@ -173,8 +173,9 @@ def require_auth(f):
             api_key = request.headers.get('X-API-Key') or request.args.get('api_key')
             
             if not API_KEY:
-                # If no API key is configured, log warning but allow access
-                logger.warning("API_KEY not configured - authentication disabled for API")
+                # If no API key is configured, allow access. Logged at DEBUG to avoid
+                # per-request noise from the dashboard/Grafana polling /api/stats.
+                logger.debug("API_KEY not configured - authentication disabled for API")
                 return f(*args, **kwargs)
             
             if not api_key:
@@ -387,13 +388,17 @@ def parse_eagle_xml(xml_data):
             data['current_block'] = elem.findtext('CurrentBlock', '')
             data['current_price'] = elem.findtext('CurrentPrice', '')
         
-        # Log unknown message types
+        # Unhandled message types: record the type and log the full payload so its
+        # contents can be inspected before deciding whether to store them.
         else:
-            # Find the first child element of rainforest to identify message type
             for child in root:
                 if child.tag != 'rainforest':
                     data['message_type'] = 'unknown_' + child.tag.lower()
-                    logger.warning(f"Unknown message type: {child.tag}")
+                    try:
+                        payload = ET.tostring(child, encoding='unicode').strip()
+                    except Exception:
+                        payload = '<unserializable>'
+                    logger.warning(f"Unhandled message type {child.tag}: {payload}")
                     break
         
         return data
@@ -454,7 +459,18 @@ def eagle_webhook():
         
         if 'message_text' in data:
             point.field("message_text", data['message_text'])
-        
+
+        # Messages with no storable fields (DeviceInfo, BillingPeriodList, TimeCluster,
+        # BlockPriceDetail, etc.) carry only metadata. A fieldless InfluxDB write always
+        # fails, so acknowledge them without attempting one.
+        storable_fields = ('power_w', 'energy_delivered_kwh', 'energy_received_kwh',
+                           'price_per_kwh', 'link_strength', 'message_text')
+        if not any(field in data for field in storable_fields):
+            stats['filtered_requests'] += 1
+            logger.debug(f"No storable fields for message_type={data.get('message_type')}; acknowledged without write")
+            return jsonify({'status': 'ignored', 'reason': 'no_storable_fields',
+                            'message_type': data.get('message_type')}), 200
+
         # Write to InfluxDB
         if write_api:
             try:


### PR DESCRIPTION
## Summary

Two log-hygiene/observability changes to the Eagle ingestion path, both pre-existing issues found while reviewing logs after the staleness-monitor rollout.

### 1. Demote the `API_KEY not configured` warning to DEBUG
It fired on **every** `/api/stats` request — the linknode-web/Grafana dashboard polls that endpoint continuously, so it was pure repeating noise. `/api/stats` is intentionally open (no `EAGLE_API_KEY` set), so the condition is expected, not actionable. Note: actually setting `EAGLE_API_KEY` would enable auth and **break the dashboard** (it doesn't send a key), so demoting the log is the right move rather than "fixing" it by requiring auth.

### 2. Surface the contents of unhandled message types
The Eagle periodically sends message types the parser has no handler for — observed: `DeviceInfo`, `BillingPeriodList`. Previously we logged only the tag name. Now we log the **full XML payload** so the actual values can be inspected:
```
WARNING - Unhandled message type DeviceInfo: <DeviceInfo>...</DeviceInfo>
```
This is deliberately a look-first step: once we see what these carry, we can decide in a follow-up whether any fields are worth storing.

### 3. Skip the doomed write for fieldless messages
Metadata messages (and the already-known-but-unstored `TimeCluster` / `BlockPriceDetail`) produce an InfluxDB point with **no fields**, which always fails the write — inflating `failed_writes` and logging an error per message. They're now acknowledged with `200 {"status":"ignored"}` and counted under `filtered_requests`, with no write attempted. No data is lost (these were never being stored).

## Verification
- [x] `python -m py_compile app.py`
- [ ] After deploy: `fly logs` shows the full `DeviceInfo`/`BillingPeriodList` payloads, no more per-poll `API_KEY not configured`, and no fieldless write errors

## Follow-up
Once the `DeviceInfo` / `BillingPeriodList` payloads are visible in the logs, decide which fields (if any) are worth persisting and add explicit handlers.

Independent of #38 (different lines); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)