### PR TITLE
feat(eagle-bypass): persistent stats counters (dual-copy CRC, reboot/runtime tracking)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,6 +61,33 @@ Then a single real send while the cloud is down (`-v` shows HTTP 200 per message
 python3 /opt/eagle-bypass/eagle_bypass.py --once -v
 ```
 
+## Stats
+
+The service keeps counters in RAM and mirrors them to a RAM-backed live file every
+cycle, so you can query current state without parsing the journal:
+
+```sh
+ssh pi@<pi-ip> cat /run/eagle-bypass/stats.json | jq
+```
+
+Counters include cycles, standby vs active, `activations` (how often the device
+stalled and the bypass stepped in), ships and per-type message success, `read_failures`
+by kind (timeout / 503 / empty), `longest_clean_run_s`, daily buckets, and
+`restarts` / `reboots` (the latter only counts real OS reboots, via the kernel boot
+id). `flash_saves` counts the hourly checkpoints and is a rough downtime-excluded
+running-hours estimate.
+
+Persistence is wear-conscious: the live file lives on tmpfs (`RuntimeDirectory`,
+zero SD writes), while **two** CRC-tagged copies are checkpointed to flash
+(`StateDirectory`) once an hour and on graceful stop. On start the service restores
+from whichever copy has a valid CRC, so a corrupt write during a power loss can't
+lose the counters. Nothing here holds secrets. To read the counters when the service
+is stopped:
+
+```sh
+sudo -u pi python3 /opt/eagle-bypass/eagle_bypass.py --print-stats
+```
+
 ## Notes
 
 - **Failover vs. always-on:** default is failover. Add `--force` to the

--- a/deploy/eagle-bypass.service
+++ b/deploy/eagle-bypass.service
@@ -30,6 +30,14 @@ Restart=always
 RestartSec=15
 SyslogIdentifier=eagle-bypass
 
+# Stats. Live counters mirror to RAM every cycle (/run/eagle-bypass, tmpfs, zero
+# SD wear) for querying; hourly CRC-protected checkpoints go to flash
+# (/var/lib/eagle-bypass, survives reboots). systemd creates both dirs owned by
+# User=, exposes them as $RUNTIME_DIRECTORY / $STATE_DIRECTORY, and both remain
+# writable under ProtectSystem=strict below.
+RuntimeDirectory=eagle-bypass
+StateDirectory=eagle-bypass
+
 # Light hardening: the script only reads the repo and talks to the network.
 NoNewPrivileges=true
 ProtectSystem=strict

--- a/scripts/eagle_bypass.py
+++ b/scripts/eagle_bypass.py
@@ -40,13 +40,17 @@ Usage:  python eagle_bypass.py [--interval 30] [--stale-secs 90] [--probe-secs 3
 
 import argparse
 import base64
+import json
 import os
 import re
+import signal
 import socket
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
+import zlib
 from datetime import datetime, timezone
 
 # ---- local API (read side) -------------------------------------------------
@@ -75,6 +79,30 @@ DEVICE_QUERY = (
     "<DeviceDetails><HardwareAddress>{mac}</HardwareAddress></DeviceDetails>"
     "<Components><All>Y</All></Components></Command>"
 )
+
+# ---- stats persistence -----------------------------------------------------
+# Counters live in RAM, are mirrored to a RAM-backed live file every cycle (systemd
+# RuntimeDirectory, /run/eagle-bypass) for zero-wear querying, and are checkpointed
+# once an hour to TWO CRC-protected copies on flash (systemd StateDirectory,
+# /var/lib/eagle-bypass). On start we restore from whichever copy has a valid CRC.
+# systemd supplies both dirs; if unset (e.g. a manual run) persistence is disabled.
+FLUSH_INTERVAL_S = 3600  # checkpoint cadence to flash
+
+
+def _cfg_dir(*env_names):
+    for n in env_names:
+        p = os.environ.get(n)
+        if p:
+            try:
+                os.makedirs(p, exist_ok=True)
+                return p if os.access(p, os.W_OK) else None
+            except OSError:
+                return None
+    return None
+
+
+RUNTIME_DIR = _cfg_dir("RUNTIME_DIRECTORY", "EAGLE_RUNTIME_DIR")
+STATE_DIR = _cfg_dir("STATE_DIRECTORY", "EAGLE_STATE_DIR")
 
 
 def now_iso():
@@ -235,11 +263,241 @@ def post_eagle(xml, timeout=15):
         return None, f"{type(e).__name__}: {e}"
 
 
-def ship(dry_run=False, verbose=False):
+def _utc_day():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _boot_id():
+    # Changes on every OS boot; lets us tell a real Pi reboot from a service restart.
+    try:
+        with open("/proc/sys/kernel/random/boot_id", "r") as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def _classify_read_error(err):
+    e = (err or "").lower()
+    if "503" in e:
+        return "http_503"
+    if "timeout" in e or "timed out" in e:
+        return "timeout"
+    return "http_other"
+
+
+class Stats:
+    """In-RAM counters, mirrored to a live RAM file each cycle and checkpointed to
+    two CRC-protected flash copies hourly. On start, restore from a valid copy."""
+
+    SCHEMA = 1
+
+    def __init__(self, runtime_dir, state_dir):
+        self.live_path = os.path.join(runtime_dir, "stats.json") if runtime_dir else None
+        self.copies = ([os.path.join(state_dir, "stats.a.json"),
+                        os.path.join(state_dir, "stats.b.json")] if state_dir else [])
+        self._last_flush = time.monotonic()
+        self.d = self._fresh()
+        self._restore()
+
+    def _fresh(self):
+        n = now_iso()
+        return {
+            "schema": self.SCHEMA,
+            "first_started_at": n, "process_started_at": n,
+            "last_saved_at": None, "save_seq": 0,
+            "restarts": 0, "reboots": 0, "boot_id": _boot_id(),
+            "mode": "starting", "last_cloud_age_s": None,
+            "cycles": 0, "standby_cycles": 0, "active_cycles": 0, "activations": 0,
+            "ship_cycles": 0, "messages_sent": 0, "messages_ok": 0, "messages_failed": 0,
+            "read_failures": {"timeout": 0, "http_503": 0, "http_other": 0, "empty": 0},
+            "last_activation": None, "last_ship": None,
+            "longest_clean_run_s": 0, "clean_run_since": n,
+            "utc_day": _utc_day(), "activations_today": 0, "ships_today": 0,
+        }
+
+    # ---- restore / persist -------------------------------------------------
+    def _read_copy(self, path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                outer = json.load(f)
+            body = outer["stats_json"]
+            if zlib.crc32(body.encode("utf-8")) != outer["crc32"]:
+                log(f"stats: CRC mismatch on {os.path.basename(path)}; ignoring")
+                return None
+            return json.loads(body)
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            log(f"stats: unreadable {os.path.basename(path)} ({type(e).__name__}); ignoring")
+            return None
+
+    def _restore(self):
+        best = None
+        for p in self.copies:
+            data = self._read_copy(p)
+            if data is not None and (best is None or
+                                     data.get("save_seq", -1) > best.get("save_seq", -1)):
+                best = data
+        if best is None:
+            if self.copies:
+                log("stats: no valid flash copy; starting fresh counters")
+            return
+        first = best.get("first_started_at") or self.d["first_started_at"]
+        self.d.update(best)
+        self.d["first_started_at"] = first
+        self.d["process_started_at"] = now_iso()
+        self.d["restarts"] = best.get("restarts", 0) + 1
+        # A changed kernel boot id means the Pi actually rebooted (vs a service restart).
+        cur_boot, prev_boot = _boot_id(), best.get("boot_id")
+        rebooted = cur_boot is not None and prev_boot is not None and cur_boot != prev_boot
+        self.d["reboots"] = best.get("reboots", 0) + (1 if rebooted else 0)
+        self.d["boot_id"] = cur_boot or prev_boot
+        self.d["mode"] = "starting"
+        self.d["clean_run_since"] = now_iso()   # the downtime interrupted any streak
+        self._roll_day()
+        log(f"stats: restored from flash (seq={best.get('save_seq')}, "
+            f"restart #{self.d['restarts']}, reboots={self.d['reboots']}, rebooted={rebooted})")
+
+    def _atomic_write(self, path, text, fsync=False):
+        d = os.path.dirname(path)
+        fd, tmp = tempfile.mkstemp(dir=d, prefix=".tmp-", suffix=".json")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(text)
+                f.flush()
+                if fsync:
+                    os.fsync(f.fileno())
+            os.replace(tmp, path)
+            if fsync:
+                try:
+                    dfd = os.open(d, os.O_RDONLY)
+                    try:
+                        os.fsync(dfd)
+                    finally:
+                        os.close(dfd)
+                except OSError:
+                    pass
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def flush(self):
+        """Checkpoint to both flash copies, each atomic and CRC-tagged. Cheap, rare."""
+        if not self.copies:
+            return
+        try:
+            self.d["save_seq"] += 1
+            self.d["last_saved_at"] = now_iso()
+            body = json.dumps(self.d, sort_keys=True, separators=(",", ":"))
+            outer = json.dumps({"crc32": zlib.crc32(body.encode("utf-8")), "stats_json": body})
+            for p in self.copies:           # copy A then B; at least one stays valid
+                self._atomic_write(p, outer, fsync=True)
+            self._last_flush = time.monotonic()
+            log(f"stats: checkpointed to flash (seq={self.d['save_seq']}, 2 copies)")
+        except Exception as e:
+            log(f"stats: flash checkpoint failed ({type(e).__name__}: {e})")
+
+    def maybe_flush(self):
+        if self.copies and (time.monotonic() - self._last_flush) >= FLUSH_INTERVAL_S:
+            self.flush()
+
+    def _snapshot(self):
+        d = dict(self.d)
+        now = datetime.now(timezone.utc)
+
+        def age(iso):
+            try:
+                return round((now - datetime.fromisoformat(iso)).total_seconds())
+            except Exception:
+                return None
+
+        d["snapshot_at"] = now.isoformat()
+        d["process_uptime_s"] = age(d["process_started_at"])
+        d["total_uptime_s"] = age(d["first_started_at"])
+        cur = age(d["clean_run_since"]) if d.get("clean_run_since") else None
+        d["current_clean_run_s"] = cur
+        if cur and cur > d["longest_clean_run_s"]:
+            d["longest_clean_run_s"] = cur
+        # Each flash checkpoint is ~hourly, so the save count is a downtime-excluded
+        # estimate of accumulated running hours (survives reboots; total_uptime_s does not).
+        d["flash_saves"] = d.get("save_seq", 0)
+        d["approx_running_h"] = d.get("save_seq", 0)
+        return d
+
+    def write_live(self):
+        if not self.live_path:
+            return
+        try:
+            self._atomic_write(self.live_path, json.dumps(self._snapshot(), indent=2))
+        except Exception:
+            pass   # stats bookkeeping must never break the failover loop
+
+    # ---- counter updates ---------------------------------------------------
+    def _roll_day(self):
+        today = _utc_day()
+        if self.d.get("utc_day") != today:
+            self.d["utc_day"] = today
+            self.d["activations_today"] = 0
+            self.d["ships_today"] = 0
+
+    def note_cycle(self, mode, cloud_age):
+        self._roll_day()
+        self.d["cycles"] += 1
+        self.d["mode"] = mode
+        self.d["last_cloud_age_s"] = None if cloud_age is None else round(cloud_age)
+        if mode == "standby":
+            self.d["standby_cycles"] += 1
+        else:
+            self.d["active_cycles"] += 1
+
+    def note_activation(self):
+        since = self.d.get("clean_run_since")
+        if since:
+            try:
+                dur = (datetime.now(timezone.utc) - datetime.fromisoformat(since)).total_seconds()
+                if dur > self.d["longest_clean_run_s"]:
+                    self.d["longest_clean_run_s"] = round(dur)
+            except Exception:
+                pass
+        self.d["activations"] += 1
+        self.d["activations_today"] += 1
+        self.d["last_activation"] = now_iso()
+        self.d["clean_run_since"] = now_iso()
+
+    def note_ship(self, sent, ok):
+        self.d["ship_cycles"] += 1
+        self.d["ships_today"] += 1
+        self.d["messages_sent"] += sent
+        self.d["messages_ok"] += ok
+        self.d["messages_failed"] += max(0, sent - ok)
+        self.d["last_ship"] = now_iso()
+
+    def note_read_failure(self, kind):
+        self.d["read_failures"][kind] = self.d["read_failures"].get(kind, 0) + 1
+
+
+def print_stats():
+    """Print the running service's live snapshot, or the newest valid flash copy."""
+    for path in [p for p in [RUNTIME_DIR and os.path.join(RUNTIME_DIR, "stats.json"),
+                             "/run/eagle-bypass/stats.json"] if p]:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                print(f.read())
+            return
+        except OSError:
+            continue
+    print(json.dumps(Stats(None, STATE_DIR or "/var/lib/eagle-bypass")._snapshot(), indent=2))
+
+
+def ship(stats, dry_run=False, verbose=False):
     """Read the meter and push whatever telemetry it has. Returns True if we sent
     (or would have) at least one message."""
     readings, meter_mac, err = read_meter()
     if err:
+        stats.note_read_failure(_classify_read_error(err))
         log(f"local read failed ({err}); nothing to ship")
         return False
     meter_mac = meter_mac or METER_MAC_FALLBACK
@@ -253,6 +511,7 @@ def ship(dry_run=False, verbose=False):
         outbox.append(("price", msg_price(readings["price"], meter_mac)))
 
     if not outbox:
+        stats.note_read_failure("empty")
         log("local API returned no demand/summation/price; nothing to ship")
         return False
 
@@ -276,11 +535,12 @@ def ship(dry_run=False, verbose=False):
             ok += 1
         else:
             log(f"  {name}: upload FAILED HTTP {status} {body}")
+    stats.note_ship(len(outbox), ok)
     log(f"shipped {ok}/{len(outbox)} messages  [{summary}]")
     return ok > 0
 
 
-def run_loop(args):
+def run_loop(args, stats):
     active = args.force            # force => always active
     probing = False               # currently in a one-cycle upload pause?
     last_probe = time.monotonic()
@@ -288,17 +548,20 @@ def run_loop(args):
     while True:
         age = fly_age_seconds()
         age_str = "unknown" if age is None else f"{round(age)}s"
+        mode = "active"           # refined below for the standby/probing cases
 
         if args.force:
-            ship(dry_run=args.dry_run, verbose=args.verbose)
+            ship(stats, dry_run=args.dry_run, verbose=args.verbose)
         elif not active:
             # Standby: activate only when the cloud path has gone stale.
             if age is None or age > args.stale_secs:
                 active = True
                 last_probe = time.monotonic()
                 log(f"cloud stale (age={age_str} > {args.stale_secs}s) -> ACTIVATING bypass")
-                ship(dry_run=args.dry_run, verbose=args.verbose)
+                stats.note_activation()
+                ship(stats, dry_run=args.dry_run, verbose=args.verbose)
             else:
+                mode = "standby"
                 log(f"cloud healthy (age={age_str}) -> standby")
         else:
             # Active. Our own ships keep `age` fresh, so we can't read recovery off
@@ -307,17 +570,23 @@ def run_loop(args):
                 probing = False
                 if age is not None and age <= args.stale_secs:
                     active = False
+                    mode = "standby"
                     log(f"probe: cloud fresh while we were silent (age={age_str}) "
                         f"-> Rainforest recovered, RETURNING TO STANDBY")
                 else:
                     log(f"probe: still stale (age={age_str}) -> resuming shipping")
-                    ship(dry_run=args.dry_run, verbose=args.verbose)
+                    ship(stats, dry_run=args.dry_run, verbose=args.verbose)
             elif (time.monotonic() - last_probe) >= args.probe_secs:
                 probing = True
                 last_probe = time.monotonic()
+                mode = "probing"
                 log("probe: pausing uploads one cycle to test whether Rainforest recovered")
             else:
-                ship(dry_run=args.dry_run, verbose=args.verbose)
+                ship(stats, dry_run=args.dry_run, verbose=args.verbose)
+
+        stats.note_cycle(mode, age)
+        stats.write_live()
+        stats.maybe_flush()
 
         if args.once:
             return
@@ -335,7 +604,13 @@ def main():
     ap.add_argument("--once", action="store_true", help="run a single cycle and exit")
     ap.add_argument("--dry-run", action="store_true", help="build and print XML; do not POST")
     ap.add_argument("-v", "--verbose", action="store_true", help="log each upload's HTTP result")
+    ap.add_argument("--print-stats", action="store_true",
+                    help="print the current stats snapshot (JSON) and exit")
     args = ap.parse_args()
+
+    if args.print_stats:
+        print_stats()
+        return
 
     if not CLOUD_ID or not INSTALL_CODE:
         log("FATAL: set EAGLE_CLOUD_ID and EAGLE_INSTALL_CODE (local API auth)")
@@ -344,11 +619,26 @@ def main():
         log("FATAL: set EAGLE_UPLOAD_PASSWORD (the EAGLE_PASSWORD secret on the Fly app)")
         sys.exit(2)
 
+    stats = Stats(RUNTIME_DIR, STATE_DIR)
+    log("stats: live=%s, flash=%s" % (
+        RUNTIME_DIR or "off (in-RAM only)",
+        ("2 CRC copies in " + STATE_DIR) if STATE_DIR else "off (no StateDirectory)"))
+
+    def _flush_and_exit(signum, _frame):
+        stats.flush()
+        log(f"stats: checkpointed on signal {signum}; exiting")
+        sys.exit(0)
+    try:
+        signal.signal(signal.SIGTERM, _flush_and_exit)   # systemd stop / reboot
+    except (ValueError, AttributeError, OSError):
+        pass   # e.g. not the main thread, or unsupported platform
+
     mode = "FORCE (always-on)" if args.force else f"FAILOVER (stale>{args.stale_secs}s)"
     log(f"eagle_bypass starting: {mode}, every {args.interval}s, Eagle={EAGLE_IP} -> {UPLOAD_URL}")
     try:
-        run_loop(args)
+        run_loop(args, stats)
     except KeyboardInterrupt:
+        stats.flush()
         log("stopped")
 
 


### PR DESCRIPTION
Adds queryable, reboot-surviving stats to the Pi bypass so "how's it doing" is a one-line read instead of parsing the journal.

> Stacked on #43 (it needed the reconciled `/opt/eagle-bypass` deploy files). Merge #43 first, then this. GitHub will retarget this to `main` once #43 merges.

## What it does

- **RAM counters, mirrored to a tmpfs live file every cycle** for zero-SD-wear querying:
  `ssh pi cat /run/eagle-bypass/stats.json | jq` (or `--print-stats`).
- **Hourly checkpoint to TWO CRC-tagged copies on flash** (`StateDirectory`), plus a flush on graceful stop. On start it **restores from whichever copy has a valid CRC**, so a corrupt write during a power loss can't lose the counters.
- **Counters:** cycles / standby / active, `activations` (device stalls the bypass covered), ships + per-message success, `read_failures` by kind (timeout / 503 / empty), `longest_clean_run_s`, daily buckets, `restarts` vs `reboots`, and `flash_saves`.
- **`reboots` vs `restarts`:** reboots increments only when the kernel boot id changes, so a `systemctl restart` isn't miscounted as an OS reboot.
- **`flash_saves`** (hourly checkpoint count) is a downtime-excluded running-hours estimate that survives reboots, unlike wall-clock uptime.

## Wear + safety

- Live file on tmpfs (zero SD writes); only ~48 small flash writes/day (2 copies x hourly).
- Atomic writes (temp + fsync + rename, dir fsync): readers never see a partial file, and a mid-write power loss corrupts at most one copy.
- All stats IO is wrapped so it can never break the failover loop; degrades to in-RAM-only when the dirs are absent (manual runs).

## Verification

- Unit-tested locally: dual-copy CRC write, restore-carries-counters, reboot-vs-restart via boot id, single-copy-corruption recovery, both-corrupt fresh start, no-persistence fallback (all pass).
- Deployed and confirmed on the live Pi: systemd created both dirs, a restart flushed two CRC-valid copies and restored from them (`restart #1, rebooted=False`), `boot_id` is a real kernel UUID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)