### PR TITLE
docs: document the Eagle-200 failover bypass and live uptime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Eagle-200 local-API bypass: a hot-standby failover uploader that keeps the data
+  pipeline alive through the meter's hardware faults (`scripts/eagle_bypass.py`, `deploy/`)
+  - Polls the Eagle's LAN REST API and forwards synthetic Rainforest XML to the Fly
+    `/eagle` endpoint only while the real cloud path is stale, filling gaps without
+    duplicating data
+  - Runs as a systemd service on a Raspberry Pi on the home network (the one host that
+    can reach the meter; Fly cannot). See `deploy/README.md`
+  - Single standard-library-only file, so there is nothing to clone or `pip install`
+    on the Pi
+- Persistent reliability statistics for the bypass
+  - Counters kept in RAM, mirrored to a tmpfs live file each cycle for querying
+    (`/run/eagle-bypass/stats.json`, zero SD wear), and checkpointed hourly to two
+    CRC-tagged flash copies that survive reboots (restores from whichever copy is valid)
+  - Distinguishes real OS reboots from service restarts via the kernel boot id
+- Outage log with reliability analytics for the bypass
+  - Timestamps each device outage and records its duration, measured on the monotonic
+    clock so an NTP step mid-outage cannot distort it
+  - `--report` prints device uptime %, mean-time-between-outages, an outage-duration
+    histogram, an hour-of-day sparkline of when the device stalls, and a table of
+    recent outages with the readings the bypass rescued during each
+- Live uptime on the dashboard, replacing the previously hardcoded "100%"
+  - The bypass posts a small `BypassStatus` heartbeat every 15 minutes; the collector
+    surfaces it under `/api/stats.bypass_status` and the site renders it
+  - Shows **Data Uptime** (the availability a visitor actually experiences, kept high
+    by the bypass) with a **device health** sublabel (the Eagle-200's own uptime)
+  - The heartbeat is recorded out-of-band and never touches the data-freshness signal,
+    so it cannot mask the staleness / Pushover alerting during a genuine total outage
 - Pushover emergency-priority alerting for power-meter outages (`fly/eagle-monitor`)
   - Fires a siren push that repeats every 60s until acknowledged when data stops arriving
   - Triggers only on the healthy→unhealthy transition (exactly one alert per outage); recovery stays Slack-only

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ A real-time energy monitoring dashboard that tracks power consumption using Eagl
   - Slack notifications on outage and recovery (fires once per state change, no spam)
   - Pushover emergency-priority siren that repeats until acknowledged
 
+- **Failover & Resilience** (the Eagle-200 meter is failing; see [docs/THEORY_OF_OPERATION.md](docs/THEORY_OF_OPERATION.md))
+  - Local-API bypass: a Raspberry Pi on the home network polls the meter's LAN API and
+    ships synthetic Rainforest XML to the ingest endpoint whenever the meter's own
+    cloud uploader stalls (hot standby, no duplicate data). See [deploy/README.md](deploy/README.md)
+  - Persistent, CRC-checkpointed reliability stats survive reboots; `--report` prints a
+    human-readable outage and uptime report
+  - Live uptime on the dashboard: real **Data Uptime** and **device health** figures
+    driven by a heartbeat from the bypass, replacing a previously hardcoded 100%
+
 - **Modern Web Interface**
   - Dark theme with animated gradients
   - Embedded Grafana dashboard
@@ -164,6 +173,7 @@ cd fly/influxdb && flyctl deploy
 | Document | Description |
 |----------|-------------|
 | [docs/THEORY_OF_OPERATION.md](docs/THEORY_OF_OPERATION.md) | System architecture and data flow |
+| [deploy/README.md](deploy/README.md) | Eagle-200 failover bypass: install and operate on the Pi |
 | [docs/HEALTH_CHECKS.md](docs/HEALTH_CHECKS.md) | Service health endpoints |
 | [docs/REGRESSION_TESTING.md](docs/REGRESSION_TESTING.md) | Baseline management guide |
 | [docs/e2e/](docs/e2e/) | E2E testing guides |
@@ -176,6 +186,7 @@ cd fly/influxdb && flyctl deploy
 flowchart LR
     subgraph Home Network
         Eagle[Eagle-200<br/>Smart Meter]
+        Pi[Raspberry Pi<br/>failover bypass]
     end
 
     subgraph Fly.io
@@ -190,15 +201,29 @@ flowchart LR
     end
 
     Eagle -->|XML/HTTP| Monitor
+    Eagle -.->|LAN API| Pi
+    Pi -.->|synthetic XML<br/>during outages| Monitor
     Monitor -->|Write| DB
     DB -->|Query| Grafana
     Browser -->|HTTPS| Web
     Web -->|Embed| Grafana
 ```
 
+The dashed path is the failover bypass: when the Eagle's own cloud uploader stalls,
+the Pi reads the meter over the LAN and fills the gap. See [deploy/README.md](deploy/README.md).
+
 See [docs/THEORY_OF_OPERATION.md](docs/THEORY_OF_OPERATION.md) for detailed architecture diagrams.
 
 ## Recent Changes
+
+### 2026-07-14: Live uptime on the dashboard
+- Real **Data Uptime** and **device health** figures from a bypass heartbeat, replacing a hardcoded 100%
+- Outage log with reliability analytics for the bypass (`--report`: uptime %, MTBF, duration histogram, hour-of-day pattern)
+
+### 2026-07-12: Eagle-200 failover bypass
+- A Raspberry Pi polls the meter's LAN API and ships synthetic XML to fill gaps when the meter's cloud uploader stalls
+- Added because the Eagle-200 hardware is failing (storage wear causing repeated data outages)
+- Persistent, CRC-checkpointed statistics that survive reboots
 
 ### 2026-01-14: Security & Cleanup
 - Fixed critical Grafana vulnerability (anonymous Admin → Viewer)


### PR DESCRIPTION
Documents the recent work now that it's live in production.

**CHANGELOG.md** (`[Unreleased]`): adds the Eagle-200 local-API bypass, its persistent CRC-checkpointed statistics, the outage log with `--report` analytics, and the live Data Uptime / device-health dashboard tile.

**README.md**:
- New **Failover & Resilience** features section
- Pi failover path added to the architecture diagram (validated)
- `deploy/README.md` linked from the Documentation table
- Two new dated entries under Recent Changes (bypass, then live uptime)

Docs only, no code or deploy impact (the deploy workflow triggers on `fly/**`). No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)