### PR TITLE
ops(eagle-bypass): switch the Pi to always-on (--force) mode

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,7 @@
 
 `scripts/eagle_bypass.py` reads the Eagle's meter over the LAN and forwards it to
 our Fly `/eagle` endpoint as synthetic Rainforest XML, but only while the real
-cloud path is stale — a hot standby that fills gaps without duplicating data.
+cloud path is stale: a hot standby that fills gaps without duplicating data.
 
 It must run on a host that can reach the Eagle (`10.0.0.222`); Fly cannot. The
 always-on home is the Raspberry Pi, run under systemd.
@@ -26,7 +26,7 @@ scp deploy/eagle-bypass.service   pi@<pi-ip>:/tmp/
 sudo install -D -m 0755 /tmp/eagle_bypass.py /opt/eagle-bypass/eagle_bypass.py
 
 # 3. Secrets: create the env file root-only, fill it in.
-#    (start from deploy/eagle-bypass.env.example — copy it over too if you like)
+#    (start from deploy/eagle-bypass.env.example, copy it over too if you like)
 sudo install -m 0600 /dev/null /etc/eagle-bypass.env
 sudoedit /etc/eagle-bypass.env         # set EAGLE_IP, EAGLE_CLOUD_ID,
                                        # EAGLE_INSTALL_CODE, EAGLE_UPLOAD_PASSWORD
@@ -47,7 +47,7 @@ pauses one cycle to check whether Rainforest recovered.
 
 ## Verify before trusting it
 
-Run one cycle by hand first — this reads the meter and prints the XML without
+Run one cycle by hand first. This reads the meter and prints the XML without
 sending anything:
 
 ```sh

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -107,9 +107,15 @@ sudo -u pi python3 /opt/eagle-bypass/eagle_bypass.py --print-stats
 
 ## Notes
 
-- **Failover vs. always-on:** default is failover. Add `--force` to the
-  `ExecStart` line to ship every cycle regardless (only if you've disabled
-  Rainforest's uploader, else you'll get near-duplicate points).
+- **Always-on (current) vs. failover:** the Pi now runs `--force` (always-on),
+  because Rainforest removed the Eagle's own cloud uploader (at our request, to cut
+  device load), so the Pi is the sole source. If the device ever uploads on its own
+  again, drop `--force` and use `--stale-secs 90 --probe-secs 300` to return to
+  failover, else you'll get near-duplicate points.
+- **What "device health" means now:** with the cloud uploader gone, the meaningful
+  reliability signal is local-API read success (`read_failures` per cycle), i.e.
+  whether the Eagle answers the Pi. In `--force` mode the outage log (which keyed off
+  cloud staleness) no longer accrues.
 - **The device flaps.** Its local data-CGI intermittently returns 503; the script
   logs `nothing to ship` and continues. That is expected, not a failure.
 - **Uptime heartbeat.** Every `--heartbeat-secs` (default 900s / 15 min), in *any*

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -115,7 +115,15 @@ sudo -u pi python3 /opt/eagle-bypass/eagle_bypass.py --print-stats
 - **What "device health" means now:** with the cloud uploader gone, the meaningful
   reliability signal is local-API read success (`read_failures` per cycle), i.e.
   whether the Eagle answers the Pi. In `--force` mode the outage log (which keyed off
-  cloud staleness) no longer accrues.
+  cloud staleness) no longer accrues. The other half of the picture is
+  `messages_failed` / `messages_sent`: how often the Fly endpoint rejects or fails to
+  receive a transmission.
+- **Report rate (`--interval`, 30s).** The Eagle natively reports every ~8-10s; we
+  poll at 30s on purpose, to avoid roughly 4x the query load on the failing device and
+  because the dashboard only flags data as stale after 2 minutes. Kept at 30s even now
+  that the Pi is the primary uploader (decided 2026-07-14): nurse the hardware, do not
+  stress it. Faster resolution is one `--interval` change away if the tradeoff ever
+  shifts.
 - **The device flaps.** Its local data-CGI intermittently returns 503; the script
   logs `nothing to ship` and continues. That is expected, not a failure.
 - **Uptime heartbeat.** Every `--heartbeat-secs` (default 900s / 15 min), in *any*

--- a/deploy/eagle-bypass.service
+++ b/deploy/eagle-bypass.service
@@ -1,8 +1,8 @@
 [Unit]
 # Eagle-200 local-API bypass: poll the meter on the LAN and ship its telemetry to
-# our Fly /eagle endpoint as synthetic Rainforest XML whenever the real cloud path
-# has gone stale. See scripts/eagle_bypass.py for the full rationale.
-Description=Eagle-200 local-API bypass (failover uploader to Fly /eagle)
+# our Fly /eagle endpoint as synthetic Rainforest XML. The Pi is now the PRIMARY
+# uploader (see ExecStart). See scripts/eagle_bypass.py for the full rationale.
+Description=Eagle-200 local-API bypass (primary uploader to Fly /eagle)
 After=network-online.target
 Wants=network-online.target
 # If it keeps dying (e.g. bad EAGLE_UPLOAD_PASSWORD), stop retrying after a burst
@@ -22,9 +22,12 @@ WorkingDirectory=/opt/eagle-bypass
 # Install deploy/eagle-bypass.env.example to this path and chmod 600 it.
 EnvironmentFile=/etc/eagle-bypass.env
 
-# Failover mode with the tuning the Pi runs: poll every 30s, treat the cloud as
-# down after 90s of silence, and pause one cycle every 5 min to test recovery.
-ExecStart=/usr/bin/python3 /opt/eagle-bypass/eagle_bypass.py --interval 30 --stale-secs 90 --probe-secs 300 -v
+# Always-on mode (the tuning the Pi runs): poll every 30s and ship every cycle.
+# Rainforest removed the Eagle's own cloud uploader (at our request, to cut device
+# load), so there is no real cloud path left to fail over from and the Pi is the
+# sole source. For the failover alternative (when the device still uploads on its
+# own), drop --force and use --stale-secs 90 --probe-secs 300 instead.
+ExecStart=/usr/bin/python3 /opt/eagle-bypass/eagle_bypass.py --interval 30 --force -v
 
 Restart=always
 RestartSec=15

--- a/scripts/eagle_bypass.py
+++ b/scripts/eagle_bypass.py
@@ -24,6 +24,15 @@ FAILOVER, NOT REPLACEMENT (default)
     --once         run a single cycle and exit (for cron/systemd timer)
     --dry-run      build and print the XML; do not POST
 
+POLLING CADENCE (--interval, default 30s)
+    The Eagle natively reports InstantaneousDemand every ~8-10s. We deliberately poll
+    slower, at 30s, for two reasons: the device is failing under CPU/storage load, so
+    we avoid roughly 4x the query pressure its native rate would add; and the dashboard
+    treats data as stale only after 2 minutes, so 30s is ample resolution. The failover
+    margins assumed it too (stale-secs 90 = 3 cycles, probe-secs 300 = 10 cycles). Kept
+    at 30s even now that the Pi is the primary uploader (decided 2026-07-14): the goal
+    is to nurse the aging hardware, not to stress it.
+
 CREDENTIALS (from the environment; never logged)
     Local API (read from the Eagle):
         EAGLE_IP            default 192.168.68.63


### PR DESCRIPTION
Rainforest removed the Eagle-200's own cloud uploader (at our request, to cut device load), so there is no real cloud path left to fail over from. The Pi is now the sole uploader.

**Problem this fixes:** left in failover mode, the bypass oscillated. Its 5-minute recovery probe kept false-detecting recovery from its *own* recent uploads (age ~62s < 90s stale threshold), flipping to standby, then reactivating ~30s later when Fly went stale. Net effect: periodic ~90s data gaps and a flood of spurious `outage` counts (device-health read 45% and climbing, 84 fake outages).

**Change:** systemd unit now runs `--force` (ship every cycle). Verified live: steady shipping every ~35s, no standby/probe/activating, Fly fresh.

**New reliability signal:** with the cloud uploader gone, the metric that matters is local-API read success (`read_failures` per cycle) — whether the Eagle answers the Pi. Baseline at the flip: **2 failures in 1,841 cycles (~99.9%)**, consistent with the fault living in the cloud-upload path, not the local API.

Deploy/-only (README + systemd unit); no service deploy. Pi already updated to match. No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)