### PR TITLE
docs: Eagle-200 hardware transplant feasibility notes

### DIFF
--- a/docs/eagle-200-hardware-notes.md
+++ b/docs/eagle-200-hardware-notes.md
@@ -1,0 +1,87 @@
+# EAGLE-200 hardware transplant feasibility — research notes
+
+**Question:** when the Eagle-200 finally ages out, can we keep the meter-authenticated
+Zigbee radio and give it a new host (dodging the host-side storage wear that is killing
+it), instead of buying and BC-Hydro-provisioning a replacement? This depends entirely on
+how the device is partitioned internally.
+
+_Living notes. Started 2026-07-14._
+
+## Confirmed
+
+- **The Eagle-200 (model RFA-Z114) has TWO separate Zigbee radios, each with its own FCC
+  ID.** That means the radios are distinct, individually-certified subsystems, not one SoC
+  fused with the host. The two networks are the **Utility HAN** (to BC Hydro's meter) and
+  the **Control network** (home Zigbee subdevices).
+- **FCC IDs:**
+  - `2AC2E-68M04` = **Meshreen Technology** "JN5168 High Power ZigBee Module" (u.FL / embedded
+    antenna). Grantee `2AC2E` = Meshreen, Taiwan. Built on the **NXP JN5168**.
+  - `YCXRFA-W900` = **Rainforest Automation** "Smart Control Module RFA-W900". Grantee `YCX`
+    = Rainforest.
+- **NXP JN5168** is a 2.4 GHz 802.15.4 / ZigBee **SoC**: 32-bit RISC CPU, on-chip flash + RAM,
+  runs the ZigBee stack *and* application on-chip; host interfaces via **UART/SPI**. The
+  JN516x family shipped an NXP ZigBee **Smart Energy (CBKE)** stack, so it is capable of being
+  the SE HAN radio. Key point: it is an SoC, not a dumb network co-processor.
+- **Our own corroboration:** Rainforest labels the two radios `d8d5b9000000ef68` (HAN) and
+  `...ef69` (control). The current failure is **host-side** (filesystem/IPC: `wifi_status`
+  returns 503 with `sem '/wifi_mgr_incoming' failed to open ... No such file`), while the
+  **meter link (HAN) reads `Connected` 100%**. The valuable radio path is healthy; the dying
+  part is the host. That is exactly the split the transplant idea needs.
+
+## Likely, not yet confirmed
+
+- **Mapping (which radio is which):** best guess is **HAN = JN5168 module (`2AC2E-68M04`)**
+  and **Control = Rainforest RFA-W900 (`YCXRFA-W900`)**, because "Smart Control Module" names
+  the control network and the JN5168 is a common SE HAN choice. **Could be reversed** — needs
+  internal-photo confirmation.
+
+## Why the mapping matters
+
+- **If HAN = JN5168 SoC running SE on-chip:** the SE certificate, private key, EUI64, and the
+  live CBKE session with the meter all live **inside the module**. A replacement host would
+  just need to **read the module's UART**. Transplant becomes feasible (small project),
+  provided we can speak Rainforest's host↔module serial framing.
+- **If HAN = RFA-W900 (chip unknown):** need its chip and whether it is SoC or NCP. Unknown.
+
+## Open questions / how to resolve
+
+1. **Which physical module is the HAN radio?** → FCC internal photos for `YCXRFA-W900` and
+   `2AC2E-68M04`, or open a unit and trace the meter-facing antenna to its module.
+2. **Is the HAN module autonomous (SoC runs SE) or host-driven (NCP runs CBKE from the host)?**
+   → JN5168 supports both; determine from the firmware role / whether the module carries its
+   own app flash. This is the weekend-hack vs multi-month-slog fork.
+3. **Host↔module interface:** almost certainly a proprietary UART framing. Reverse-engineer by
+   tapping the lines between host and module.
+4. **Host storage type (the failing part):** eMMC / SD / raw NAND? If discrete and reflashable,
+   *repairing the host storage and keeping Rainforest's firmware* may beat a radio transplant
+   outright, since their FW already drives the radio + SE session.
+
+## Blockers hit during research (2026-07-14)
+
+- `fccid.io` → HTTP 403 (bot block); `fcc.report` → 521/522; `usermanual.wiki` → 522;
+  `grokipedia.com` → 403. Every automated FCC/teardown fetch is gated. Could not pull
+  internal photos or a block diagram this way.
+- **Path forward:** a real browser is not bot-blocked. Either open
+  `fccid.io/2AC2E-68M04` and `fccid.io/YCXRFA-W900` (Internal Photos + Block Diagram) by hand,
+  or drive it via the Chrome automation tools and read the board photos: identify which module
+  sits on the meter-facing antenna (= HAN), read the chip markings, and read the host storage
+  chip (eMMC/SD/NAND). That resolves questions 1, 2, and 4 above in one sitting.
+
+## Practical verdict so far
+
+- The partition the idea needs **almost certainly exists**, and one radio is **confirmed a
+  reusable commercial SoC module** (JN5168). Whether a host transplant is a small project or a
+  reverse-engineering slog comes down to (a) which radio is the HAN one and (b) SoC-vs-NCP for
+  it — both answerable from internal photos or a teardown.
+- **Lower-effort alternative still on the table:** repair/replace the host's storage (if it is a
+  discrete, reflashable part) and keep Rainforest's software intact. That sidesteps the entire
+  host-firmware problem and doesn't touch the radio.
+
+## Sources
+
+- FCC ID `2AC2E-68M04` (Meshreen JN5168 module): https://fccid.io/2AC2E-68M04
+- FCC ID `YCXRFA-W900` (Rainforest Smart Control Module): https://fccid.io/YCXRFA-W900
+- NXP JN5168 SoC (family datasheet/product page): https://www.nxp.com
+- Silicon Labs NCP vs SoC overview (host↔NCP via EZSP, for contrast):
+  https://docs.silabs.com/zigbee/latest/zigbee-coprocessors-overview/
+- EAGLE-200 product page (Rainforest): https://www.rainforestautomation.com/rfa-z114-eagle-200-2/

--- a/docs/eagle-200-hardware-notes.md
+++ b/docs/eagle-200-hardware-notes.md
@@ -9,52 +9,163 @@ _Living notes. Started 2026-07-14._
 
 ## Confirmed
 
-- **The Eagle-200 (model RFA-Z114) has TWO separate Zigbee radios, each with its own FCC
-  ID.** That means the radios are distinct, individually-certified subsystems, not one SoC
-  fused with the host. The two networks are the **Utility HAN** (to BC Hydro's meter) and
-  the **Control network** (home Zigbee subdevices).
-- **FCC IDs:**
+- **The Eagle-200 (model RFA-Z114) carries two FCC-certified radio modules, but they are NOT
+  two Zigbee radios.** The FCC filings resolve them as **one Zigbee SoC module + one Wi-Fi
+  module** (correction — see the W900 finding below):
   - `2AC2E-68M04` = **Meshreen Technology** "JN5168 High Power ZigBee Module" (u.FL / embedded
-    antenna). Grantee `2AC2E` = Meshreen, Taiwan. Built on the **NXP JN5168**.
-  - `YCXRFA-W900` = **Rainforest Automation** "Smart Control Module RFA-W900". Grantee `YCX`
-    = Rainforest.
+    antenna). Grantee `2AC2E` = Meshreen, Taiwan. Built on the **NXP JN5168**. This is the
+    **Zigbee** radio — the meter-facing HAN path. FCC filing (uploaded 2026-07-14) confirms:
+    **2405-2475 MHz** single-channel (no MIMO → 802.15.4, i.e. Zigbee, not Wi-Fi), **0.118 W**
+    (~21 dBm, hence "High Power"), **Single Modular Approval**, model series **MS5168-Mxx**,
+    original grant 2014-10-07. A discrete, off-the-shelf commercial module — exactly the kind of
+    part that is physically separable and independently documented.
+  - `YCXRFA-W900` = **Rainforest Automation** "Smart Control Module RFA-W900" (grantee `YCX`).
+    Its FCC grant RF profile is **802.11n Wi-Fi, not Zigbee**: 2412-2462 MHz, **2TX MIMO,
+    20 & 40 MHz channel bandwidths**, ~0.329 W combined conducted. Zigbee/802.15.4 has no MIMO
+    and uses 2 MHz channels, so this module is unambiguously the **2.4 GHz Wi-Fi uplink**, i.e.
+    how the gateway joins the home network — despite the "Smart Control Module" marketing name.
+    (See "The W900 filing" below for how this was established.)
 - **NXP JN5168** is a 2.4 GHz 802.15.4 / ZigBee **SoC**: 32-bit RISC CPU, on-chip flash + RAM,
   runs the ZigBee stack *and* application on-chip; host interfaces via **UART/SPI**. The
   JN516x family shipped an NXP ZigBee **Smart Energy (CBKE)** stack, so it is capable of being
   the SE HAN radio. Key point: it is an SoC, not a dumb network co-processor.
-- **Our own corroboration:** Rainforest labels the two radios `d8d5b9000000ef68` (HAN) and
+- **Our own corroboration:** Rainforest labels two Zigbee networks `d8d5b9000000ef68` (HAN) and
   `...ef69` (control). The current failure is **host-side** (filesystem/IPC: `wifi_status`
   returns 503 with `sem '/wifi_mgr_incoming' failed to open ... No such file`), while the
   **meter link (HAN) reads `Connected` 100%**. The valuable radio path is healthy; the dying
   part is the host. That is exactly the split the transplant idea needs.
 
+## The W900 filing (FCC ID YCXRFA-W900) — what the upload showed (2026-07-15)
+
+Decoded from the FCC MHT the user saved. This is the most direct data we have, and it
+**corrects the earlier "two Zigbee radios" assumption**:
+
+- **Equipment class "Digital Transmission System", Notes "Smart Control Module", Single
+  Modular approval.** A discrete, individually-certified module — good for the transplant
+  premise generally, but this one is the Wi-Fi module, not the meter radio.
+- **RF profile = Wi-Fi.** "2TX MIMO configurations", "supports 20 MHz and 40 MHz bandwidths",
+  2412-2462 MHz. Those are 802.11n features that Zigbee cannot have. So W900 ≠ meter radio.
+- **This grant is a re-identification, not an original design.** "Change in identification of
+  presently authorized equipment. Original FCC ID: **N89-WD114**", original grant 2016-02-17,
+  re-ID'd to YCXRFA-W900 on 2016-03-25. Rainforest rebadged an existing OEM Wi-Fi module under
+  their own FCC ID. The chipset is whatever `N89-WD114` is (not named in this filing).
+- **No internal photos here.** Exhibits are External Photographs, Label/Label Location, agent
+  authorization, and change-of-ID cover letters only (confidentiality: No). So this filing does
+  **not** reveal internal chip markings or a block diagram — chase `N89-WD114` for that.
+
+**Net effect on the thesis:** it *simplifies* it. The meter-authenticated Smart Energy identity
+almost certainly lives in the **one Zigbee SoC (JN5168)**, not split across two Zigbee radios.
+The W900 (Wi-Fi) is part of the flaky host/uplink side we would be *replacing*, not the radio we
+need to preserve.
+
 ## Likely, not yet confirmed
 
-- **Mapping (which radio is which):** best guess is **HAN = JN5168 module (`2AC2E-68M04`)**
-  and **Control = Rainforest RFA-W900 (`YCXRFA-W900`)**, because "Smart Control Module" names
-  the control network and the JN5168 is a common SE HAN choice. **Could be reversed** — needs
-  internal-photo confirmation.
+- **The JN5168 module is the meter HAN radio.** With W900 reclassified as Wi-Fi, the JN5168 is
+  the only certified Zigbee module in the box, so it is almost certainly the SE HAN radio (and
+  may also run the "control" Zigbee network as a second PAN on the same SoC). Still worth an
+  internal-photo / teardown confirmation, and worth checking whether a *second* Zigbee part is
+  soldered to the mainboard under the host's own composite FCC grant (which would not show up as
+  its own modular ID).
 
-## Why the mapping matters
+## Why this matters
 
-- **If HAN = JN5168 SoC running SE on-chip:** the SE certificate, private key, EUI64, and the
-  live CBKE session with the meter all live **inside the module**. A replacement host would
-  just need to **read the module's UART**. Transplant becomes feasible (small project),
-  provided we can speak Rainforest's host↔module serial framing.
-- **If HAN = RFA-W900 (chip unknown):** need its chip and whether it is SoC or NCP. Unknown.
+- **HAN = JN5168 SoC running SE on-chip (the expected case):** the SE certificate, private key,
+  EUI64, and the live CBKE session with the meter all live **inside the module**. A replacement
+  host would just need to **read the module's UART**. Transplant becomes feasible (small
+  project), provided we can speak Rainforest's host↔module serial framing.
+- **The reclassification of W900 as Wi-Fi removes the fork we worried about.** There is no
+  competing "maybe the HAN radio is the W900 with an unknown chip" branch anymore — W900 is the
+  Wi-Fi uplink. The remaining risk is not *which* radio but *how* the JN5168 is driven (SoC vs
+  NCP) and whether a second Zigbee part hides on the mainboard.
 
-## Open questions / how to resolve
+## FCC blocker found: the decisive docs are confidential (2026-07-14)
 
-1. **Which physical module is the HAN radio?** → FCC internal photos for `YCXRFA-W900` and
-   `2AC2E-68M04`, or open a unit and trace the meter-facing antenna to its module.
-2. **Is the HAN module autonomous (SoC runs SE) or host-driven (NCP runs CBKE from the host)?**
-   → JN5168 supports both; determine from the firmware role / whether the module carries its
-   own app flash. This is the weekend-hack vs multi-month-slog fork.
-3. **Host↔module interface:** almost certainly a proprietary UART framing. Reverse-engineer by
-   tapping the lines between host and module.
+The one open technical question — **does Rainforest run the Smart Energy / CBKE stack ON the
+JN5168 (SoC mode) or drive it as a bare co-processor from the host (NCP mode)?** — is exactly
+what the module's **Block Diagram, Schematics, and Operational Description** would answer. On the
+FCC filing all three are **"Metadata only"** (filed under **long-term confidentiality**; the grant
+page shows Long-Term Confidentiality = Yes). So the FCC route **cannot** resolve SoC-vs-NCP: those
+exhibits are sealed. Public exhibits are only External/Internal Photos, Label, Test Report, and
+the **User Manual (MS5168-Mxx series, public)**.
+
+Caveat on the uploads themselves: the five saved pages are the fccid.io HTML wrappers. The actual
+exhibit PDFs (internal photos, the user-manual pinout) render as page images and did **not** come
+through as readable content in the saves — I have the metadata and page counts, not the pixels.
+To actually read them I'd need the PDFs saved directly (the `/m/<hash>.pdf` links), not the
+fccid.io page as MHT.
+
+## What the Test Report (public, 47pp) adds — read 2026-07-14
+
+Extracted the report's page images (it is a scan; pulled the raster pages and read them). It does
+**not** reproduce the sealed internal block diagram, but its EUT/setup sections are informative:
+
+- **EUT specifics (confirm Zigbee):** models **MS5168-M04** (u.FL external antenna, 2.43 dBi) and
+  **MS5168-M05** (PCB antenna, 1.60 dBi); **O-QPSK**, 2405-2475 MHz, **15 channels**, **20.72 dBm**,
+  99% OBW 2.28 MHz, **DC 3.3 V**. Unambiguously the 802.15.4 / Zigbee radio.
+- **The module is host-attached and field-programmable.** Test methodology 3.2 ("EUT Exercise
+  Software"): *"Turn on Zigbee function link to Notebook and run test program"*, *"EUT run test
+  program"*, and *"Software used to control the EUT for staying in continuous transmitting mode was
+  programmed."* The setup block diagram (3.3) is **AC Adapter → Notebook → Fixture → EUT**: the
+  module sits in a fixture and is driven over a wired link by a host PC.
+- **What this settles:** the module runs **loadable application firmware on-chip** and is designed
+  to be **driven by an external host over a serial link** — precisely the "module + host" split the
+  transplant depends on, and the same shape as the EAGLE's Linux host driving it.
+- **What it does NOT settle:** whether the on-chip firmware is a *full SE/CBKE stack* (SoC mode) or
+  a *thin MAC co-processor* (NCP mode). That is the sealed Block Diagram / Schematics / Operational
+  Description, none of which the test report copies. So SoC-vs-NCP remains open after the FCC docs.
+
+## SoC-vs-NCP: RESOLVED (SoC mode), from public NXP/module docs — 2026-07-14
+
+Web research into the public JN5168 / MS5168 documentation settles the crux the sealed FCC docs
+wouldn't. The stack (and therefore the Smart Energy identity) runs **on the module**, not on the
+host. Evidence:
+
+- **The JN5168 is a full SoC that runs MAC + ZigBee PRO stack + application on-chip.** 256 KB
+  Flash, 32 KB RAM, **4 KB EEPROM plus OTP**, "access to the on-chip peripherals, MAC and network
+  stack software is provided through specific APIs." Critically, its **OTP memory securely holds a
+  64-bit MAC/IEEE address and a 128-bit AES key on-chip** — i.e. the network security material
+  lives in the silicon, not on a host. (NXP JN5168 product pages / JN516x data sheet.)
+- **The MS5168 module family explicitly targets ZigBee Smart Energy** and "use[s] NXP JN5168 ...
+  to provide a comprehensive solution with large memory, high CPU and radio performance and all RF
+  components included," with the host talking to it over **UART**. So SE is a first-class supported
+  role for this exact module, run on the module. (Meshreen MS5168-Mxx datasheet/user manual.)
+- **The canonical usage pattern keeps the stack on the module in every mode.** The Seeed MeshBee
+  (a JN5168 module) cookbook documents three modes, and the ZigBee PRO stack runs on the module in
+  all of them: *Master/AT* ("factory firmware warps the complicated Zigbee stack operation into a
+  few easy to use serial commands"), *Slave/API* ("a host application can send API frames ... to
+  interact with"), and *MCU* (run your own app on the JN5168 standalone). In no mode does the host
+  run the ZigBee stack — the host only ever speaks high-level AT/API over UART.
+- **NCP mode would mean Rainforest re-implemented the entire ZigBee PRO + Smart Energy + CBKE stack
+  on their Linux host.** NXP ships that stack on-chip for free and provides no Linux SE host stack
+  for JN516x; a small vendor writing their own is implausible.
+- **Our own telemetry corroborates it:** the host is failing (filesystem/IPC: `wifi_status` 503,
+  missing semaphore) while the **meter/HAN link stays `Connected` 100%**. A CBKE session run in host
+  software would not survive the host melting down; a session held on the module does. The SE link
+  outliving host failure is exactly the SoC-mode signature.
+
+**Conclusion:** the meter's authenticated identity — SE certificate, private key, EUI64, and the
+live CBKE session — lives **inside the JN5168 module**, and the EAGLE's Linux host only pulls
+cooked data across a UART. A replacement host therefore needs to **speak that serial link**, not
+reproduce any Zigbee/SE security. This is the favorable "small project" outcome. The only remaining
+unknown is the **application-level framing** Rainforest uses over the UART (standard NXP serial-link
+protocol vs a custom one) — a pure reverse-engineering task on public, accessible pins, with no
+cryptographic barrier. Short of a bench probe for 100% certainty, the feasibility question is
+answered: **yes, a radio-preserving host transplant is viable.**
+
+## Open questions / how to resolve (updated)
+
+1. ~~**SoC vs NCP for the JN5168**~~ — **RESOLVED: SoC mode** (section above). Only a bench probe of
+   our own unit's UART would add final 100% certainty; not required for the go/no-go call.
+2. **Is there a second Zigbee part on the mainboard** (for the "control" network) not covered by
+   its own modular FCC ID, or does the single JN5168 run both PANs? → teardown / internal photos.
+3. **Host↔module interface:** the **electrical layer is public** (JN5168 + Meshreen module pinout
+   are documented — UART/SPI). What is unknown is Rainforest's **application-level framing** over
+   that UART. De-risked physically; only the protocol is proprietary.
 4. **Host storage type (the failing part):** eMMC / SD / raw NAND? If discrete and reflashable,
    *repairing the host storage and keeping Rainforest's firmware* may beat a radio transplant
    outright, since their FW already drives the radio + SE session.
+5. **What chip is `N89-WD114`** (the OEM Wi-Fi module W900 rebadges)? Only matters if we end up
+   needing to re-host Wi-Fi too, which the transplant would likely replace anyway.
 
 ## Blockers hit during research (2026-07-14)
 
@@ -69,19 +180,38 @@ _Living notes. Started 2026-07-14._
 
 ## Practical verdict so far
 
-- The partition the idea needs **almost certainly exists**, and one radio is **confirmed a
-  reusable commercial SoC module** (JN5168). Whether a host transplant is a small project or a
-  reverse-engineering slog comes down to (a) which radio is the HAN one and (b) SoC-vs-NCP for
-  it — both answerable from internal photos or a teardown.
+- **The idea is viable.** The partition the transplant needs exists; the meter radio is a confirmed
+  reusable commercial **SoC module** (JN5168, Meshreen MS5168-Mxx); the W900 upload removed the
+  "which radio is the HAN one" uncertainty (W900 is Wi-Fi); and the SoC-vs-NCP crux is now
+  **resolved as SoC mode** from public NXP/module docs (see the RESOLVED section above). The
+  meter's SE identity lives **inside the module**; the host only reads cooked data over UART.
+- **The physical interface is already de-risked:** JN5168 + MS5168 pinouts are public (UART/SPI).
+  The only remaining unknown is Rainforest's application-level framing over that UART, and that is a
+  plain reverse-engineering task with **no cryptographic barrier** — the crypto stays on the module
+  we keep. A bench probe of our own unit would confirm the framing and give final certainty.
 - **Lower-effort alternative still on the table:** repair/replace the host's storage (if it is a
   discrete, reflashable part) and keep Rainforest's software intact. That sidesteps the entire
   host-firmware problem and doesn't touch the radio.
+- **Next step is a project, not a question.** The one remaining unknown (Rainforest's UART framing)
+  is derived by sniffing the live host-to-module link. See the full plan in
+  [`eagle-200-transplant-plan.md`](eagle-200-transplant-plan.md).
 
 ## Sources
 
 - FCC ID `2AC2E-68M04` (Meshreen JN5168 module): https://fccid.io/2AC2E-68M04
-- FCC ID `YCXRFA-W900` (Rainforest Smart Control Module): https://fccid.io/YCXRFA-W900
-- NXP JN5168 SoC (family datasheet/product page): https://www.nxp.com
+  - EUT/setup detail read from the module's **public Test Report** exhibit (report no. 1409FR15):
+    O-QPSK 2405-2475 MHz, 20.72 dBm, models MS5168-M04/M05; setup `AC Adapter → Notebook → Fixture
+    → EUT`; firmware programmable / host-driven.
+- FCC ID `YCXRFA-W900` (Rainforest "Smart Control Module", actually the **Wi-Fi** module, re-ID of
+  N89-WD114): https://fccid.io/YCXRFA-W900
+- NXP JN5168 product page (256 KB Flash / 32 KB RAM / 4 KB EEPROM+OTP; on-chip MAC+stack via APIs;
+  OTP holds 64-bit MAC + 128-bit AES key): https://www.nxp.com/part/JN5168
+- NXP JN516x ZigBee Smart Energy (SE stack incl. CBKE runs on the JN516x):
+  https://www.nxp.com/pages/jn516x-zigbee-smart-energy:ZIGBEE-SMART-ENERGY
+- Meshreen MS5168-Mxx (module family targets ZigBee Smart Energy; JN5168 + all RF; UART host):
+  https://www.meshreen.com/ms5168-m04-2/
+- Seeed MeshBee cookbook (JN5168 module; stack-on-module in all three modes — AT / API / MCU;
+  host talks high-level AT/API over UART): https://files.seeedstudio.com/wiki/Mesh_Bee/res/MeshBee_Cook_Book.pdf
 - Silicon Labs NCP vs SoC overview (host↔NCP via EZSP, for contrast):
   https://docs.silabs.com/zigbee/latest/zigbee-coprocessors-overview/
 - EAGLE-200 product page (Rainforest): https://www.rainforestautomation.com/rfa-z114-eagle-200-2/

--- a/docs/eagle-200-transplant-plan.md
+++ b/docs/eagle-200-transplant-plan.md
@@ -1,0 +1,307 @@
+# EAGLE-200 radio transplant: UART sniffing and protocol-derivation project plan
+
+**Goal.** Before the EAGLE-200's host board finally dies, capture and decode the serial protocol
+between its host MCU and its Zigbee module, so that a replacement host can drive the *same*
+meter-authenticated Zigbee radio and keep linknode.com alive without a BC-Hydro re-provisioning.
+
+**Status of the premise (settled).** See [`eagle-200-hardware-notes.md`](eagle-200-hardware-notes.md)
+for the evidence. In short: the meter radio is a discrete, reusable **NXP JN5168 SoC module**
+(Meshreen MS5168-Mxx, FCC `2AC2E-68M04`); the Smart Energy identity (certificate, private key,
+EUI64, live CBKE session) lives **inside that module**; and the host only reads cooked data across
+a serial link. The failing part is the host, not the radio. That makes a host transplant viable and
+reduces the whole problem to **one question this project answers: what does the host say to the
+module over that link, and what does the module say back?**
+
+_Living plan. Started 2026-07-14._
+
+---
+
+## 1. Why now, and why non-destructive first
+
+- **Capture while the unit is alive.** The host is degrading (filesystem/IPC faults) but still boots
+  and still brings the module up (meter link reads `Connected` 100%). The boot / network-rejoin /
+  CBKE handshake only crosses the wire when the host initialises the module. Once host storage fully
+  dies we may only ever see steady-state traffic, or nothing. **The init sequence is far easier to
+  get before the host is gone.**
+- **The tap is passive and reversible.** We only *listen*: analyzer inputs on the module TX, the host
+  TX (module RX), and a ground. Nothing is driven. Open the case, tack on three fine wires, capture,
+  remove them, reassemble. The EAGLE keeps working. There is no downside to doing it opportunistically,
+  and it is worth doing **purely as insurance even if we never transplant**.
+- **We already have the plaintext.** We poll the Eagle local API and get decoded meter values
+  (`InstantaneousDemand`, `CurrentSummationDelivered`) with timestamps. This turns blind reverse
+  engineering into a **known-plaintext alignment problem**: capture the UART and poll the API at the
+  same time, line the timestamps up, and the known values appear in the byte stream where the field
+  encoding can be read off directly.
+
+## 2. Scope
+
+**In scope**
+- Physically locate and passively tap the host to module serial link inside the EAGLE-200.
+- Determine the electrical interface (UART vs SPI), baud/clocking, and framing.
+- Capture representative traffic: cold-boot handshake, network (re)join, and steady-state reads.
+- Correlate captured frames against local-API ground truth to decode the read path.
+- Produce a written protocol spec sufficient to build a replacement host's read path.
+- Prototype and validate that read path on a bench host (no meter needed for decode).
+
+**Out of scope (explicitly not doing)**
+- Extracting or cloning the SE certificate / private key. Not needed (we keep the module) and not
+  feasible. See hardware notes.
+- Spoofing or re-pairing a new radio with the meter. Rejected earlier.
+- Reflashing or modifying the JN5168 firmware. We drive it as-is.
+- Any change to the live production path during capture. The Pi bypass stays primary throughout.
+
+## 3. Strategy: phased, with a hard split between "insurance" and "build"
+
+Phases 1 to 5 are the **insurance package**: do them soon, while the unit lives. They are cheap,
+non-destructive, and produce a durable artifact (the protocol spec) that outlives the hardware.
+Phases 6 to 8 are the **build**: defer until the EAGLE actually ages out (or we choose to).
+
+| Phase | Name | Trigger | Destructive? |
+|---|---|---|---|
+| 1 | Access and identify the link | Now | No (open case only) |
+| 2 | Build the passive capture rig | Now | No |
+| 3 | Interface and baud discovery | Now | No |
+| 4 | Known-plaintext capture campaign | Now | No |
+| 5 | Decode and write the protocol spec | After phase 4 | No |
+| 6 | Prototype replacement host (read path) | When ready to build | No |
+| 7 | Bench validation against the real module | Before cutover | No (still reversible) |
+| 8 | Transplant and cutover | EAGLE host has died / is dying | Yes |
+
+---
+
+## 4. Equipment / bill of materials
+
+| Item | Spec / note | Rough cost |
+|---|---|---|
+| Logic analyzer | **Saleae Logic 16** (16 digital channels, selectable logic threshold covering 3.3 V, sample-rate headroom far beyond 1 Mbaud) | on hand |
+| Capture software | **Saleae Logic 2**, driven through its **15-tool MCP interface** (see 4.1); built-in UART and SPI analyzers | on hand |
+| Fine-tip probes / micro test hooks | To grab module castellations or nearby test points | $10 to $30 |
+| 30 AWG wire + soldering iron | Tack wires to pads if hooks will not grab | on hand |
+| Multimeter | Continuity / 3.3 V rail check before connecting | on hand |
+| Oscilloscope (optional) | To eyeball logic swing and idle-high line before committing the analyzer | optional |
+| Anti-static mat / strap | Handling an open Zigbee board | on hand |
+| Capture host + Pi | Workstation running Logic 2 + the MCP; the Pi polls the local API for the plaintext table | on hand |
+
+The Logic 16 and its software are on hand; only hooks/wire may need buying.
+
+### 4.1 Toolchain and automation: Saleae Logic 16 + MCP
+
+The Logic 16 is driven by **Saleae Logic 2**, which exposes an automation surface reachable here as a
+**15-tool MCP interface**. That turns capture from manual clicking into a **scriptable, repeatable
+loop that Claude can drive directly** when the MCP is connected: enumerate the device, set the active
+channels / sample rate / logic threshold, start and stop timed captures, attach a UART (or SPI)
+analyzer, and export the decoded frames and raw transitions for analysis. The correlation step
+(align exported frames to the Pi's timestamped local-API log) then runs as code, so a capture ->
+export -> decode -> refine cycle can iterate quickly and reproducibly.
+
+Two practical consequences for this plan:
+
+- **16 channels means no iterative guessing.** Tap *every* candidate line at once, both UARTs
+  (`TXD0/RXD0`, `TXD1/RXD1`), the flow-control pair (`RTS0/CTS0`), and the SPI candidates
+  (`SCLK/MOSI/MISO/CS`), in a single capture. One boot recording then reveals which interface and
+  which pins actually carry the meter traffic, collapsing phase 3 into one shot instead of a probe-
+  and-retry loop.
+- **Where the tools must be live.** The MCP is only useful in the session physically attached to the
+  Logic 16 (the workstation by the EAGLE). This session does **not** have those tools connected, so
+  the steps below are written so that whoever runs the capture (a future session with the Saleae MCP
+  loaded, or a human in Logic 2) can execute them the same way. When the MCP is live, Claude can
+  operate the capture end to end.
+
+---
+
+## 5. Phase detail
+
+### Phase 1 - Access and identify the link
+
+1. Power down, open the EAGLE-200 enclosure (record every screw/clip; this stays reassemble-able).
+2. Identify the Zigbee module: the daughter-module/shielded can bearing FCC `2AC2E-68M04`, with the
+   u.FL connector (M04 variant) or PCB antenna (M05). Photograph the board (both sides) before touching.
+3. From the **MS5168-Mxx datasheet pinout**, find the module's serial pins: `TXD0`/`RXD0` and their
+   flow-control mates `RTS0`/`CTS0`, plus `TXD1`/`RXD1` if present, and a `GND` and the `3V3` rail.
+   Note: the JN516x serial bootloader lives on **UART0**, so data traffic may be on UART0 or UART1;
+   confirm empirically in phase 3.
+4. Map those module pins to reachable copper: the castellated pad, a series resistor, a via, or a test
+   point on the host side of the link. Prefer the easiest solid contact for a listen-only tap.
+5. Confirm the logic rail with a meter (expect ~3.3 V, idle-high on an idle UART TX line).
+
+**Gate A output:** confirmed physical tap points for module-TX, host-TX, and GND.
+
+### Phase 2 - Build the passive capture rig
+
+With 16 channels available, wire **all** candidate lines at once (listen only, never drive) so a
+single boot capture identifies the real interface:
+
+| CH | Signal | Purpose |
+|---|---|---|
+| CH0 | module `TXD0` | UART0 module -> host |
+| CH1 | host `TXD0` (module `RXD0`) | UART0 host -> module |
+| CH2 | `RTS0` | UART0 flow control (explains gated bursts) |
+| CH3 | `CTS0` | UART0 flow control |
+| CH4 | module `TXD1` | UART1 module -> host (if present) |
+| CH5 | host `TXD1` (module `RXD1`) | UART1 host -> module |
+| CH6 | `SCLK` | SPI clock candidate |
+| CH7 | `MOSI` | SPI host -> module candidate |
+| CH8 | `MISO` | SPI module -> host candidate |
+| CH9 | `CS` / `SSEL` | SPI chip-select candidate |
+| CH10 | `RSTN` | module reset (marks bring-up boundary) |
+| CH11 | optional strobe | manual event marker during capture |
+| GND | board ground | common reference (never a signal) |
+
+1. Tack the wires to the mapped pads/test points from phase 1. Keep stubs short; 1 Mbaud tolerates
+   it, but tidy is better. Any candidate line that turns out not to exist on this board is simply an
+   idle channel, no harm.
+2. In Logic 2 (via MCP), set the logic threshold to the 3.3 V range and pick a sample rate giving
+   comfortable oversampling (target >= ~16 samples per bit at the expected baud).
+3. Sanity check: power on, confirm idle-high UART lines and bursts of activity. Do **not** yet worry
+   about decoding.
+
+### Phase 3 - Interface and baud discovery (single capture)
+
+Because every candidate line is already tapped (phase 2), one boot capture answers this:
+
+1. **Which interface.** See which channels carry traffic. Async self-clocked bursts on CH0/CH1 (or
+   CH4/CH5) with no companion clock = UART. Activity gated by a clock on CH6 = SPI; if so, decode the
+   SPI group instead. UART is the expected and far more likely case; the SPI channels are insurance.
+2. **Which UART.** If both UART0 and UART1 show traffic, keep the pair whose payload tracks meter
+   reads (phase 4); the other is likely a debug/ISP console.
+3. **Baud / clock.** Measure the narrowest pulse; its width is one bit time. Candidate UART rates:
+   - **1,000,000 baud, 8N1** - common default for the NXP JN51xx serial-link host interface.
+   - **115200 / 38400 8N1** - generic defaults; 38400 is the JN51xx bootloader rate.
+   Set the analyzer to the measured rate and confirm clean byte framing (no framing errors). For SPI,
+   read the clock polarity/phase and word size off the capture.
+
+**Gate B output:** interface type, the live channel pair, and line settings locked; the analyzer
+produces clean bytes in both directions.
+
+### Phase 4 - Known-plaintext capture campaign
+
+Drive the Logic 16 through the MCP to run timed captures and export decoded frames, while the Pi
+timestamps local-API polls, so every captured second has a ground-truth row
+`(t, InstantaneousDemand, CurrentSummationDelivered, ...)` to align against. Keep the two clocks
+comparable (same NTP-synced host, or record an offset) so the alignment is tight.
+
+Captures to collect:
+1. **Cold boot / init.** Start the capture, then power the EAGLE on. Grab the full module bring-up:
+   reset, firmware/version handshake, network parameters, rejoin, and the CBKE/key exchange chatter.
+   This is the perishable one, prioritise it.
+2. **Steady state.** Several minutes of normal operation. The Eagle reads instantaneous demand every
+   ~8 to 10 s natively, so the periodic request/response pair should be obvious and repeating.
+3. **Event-correlated.** While capturing, watch the local API for a demand value change; the matching
+   frame is the one whose payload changes in step. Toggle the CH3 strobe (or note the time) at that
+   instant to bookmark it.
+4. **Provisioning traffic if it ever occurs** (e.g. a rejoin). Treat as **sensitive**: link-layer
+   key or install-code material could cross the wire here. See section 7.
+
+Save every capture with a written log: date, firmware state of the host, what you did, and the
+concurrent local-API dump.
+
+### Phase 5 - Decode and write the protocol spec
+
+1. **Find the framing.** Identify start/sync byte(s), a length field, a message-type/command byte,
+   payload, and a trailing checksum/CRC. If Rainforest used the stock NXP serial link, the frame has a
+   documented shape (start byte, type, length, payload, CRC-style check); if custom, derive it from
+   repetition and the known-plaintext anchors.
+2. **Anchor on known values.** Locate the `InstantaneousDemand` integer in a steady-state response by
+   matching the local-API value; walk outward to recover scale/divisor, endianness, and the enclosing
+   length and checksum. Repeat for `CurrentSummationDelivered`.
+3. **Classify message types.** Separate host-initiated requests from module-initiated reports; note
+   which request elicits a reading, and any periodic keep-alive.
+4. **Deliverable:** `docs/eagle-200-serial-protocol.md` - interface + line settings, frame format,
+   message-type table, field encodings for the read path, and the exact request needed to obtain a
+   reading. This artifact is the point of the whole insurance exercise.
+
+**Decision gate C:** can we, on paper, (a) recognise a reading and (b) name the request that produces
+one? If yes, the transplant read path is fully specified and the insurance goal is met.
+
+### Phase 6 - Prototype replacement host (read path)
+
+- Choose a host: a Pi or a small Linux/MCU board with a 3.3 V UART.
+- Implement the request/parse loop from the phase-5 spec; reuse the existing synthetic-Rainforest-XML
+  uploader from `scripts/eagle_bypass.py` for the shipping side, so only the *acquisition* front end
+  is new.
+- Develop against captures first (replay), then against the live module.
+
+### Phase 7 - Bench validation against the real module
+
+- Connect the prototype host to the module's UART (still inside the powered EAGLE, still reversible)
+  in **parallel-listen** first, then, only if confident, as the driver on a bench where we can restore
+  the original host.
+- Success = prototype reads `InstantaneousDemand` and summation from the module and they match the
+  local API within tolerance, sustained across rejoin and over hours.
+
+### Phase 8 - Transplant and cutover (deferred until the EAGLE ages out)
+
+- Mechanically separate the module from the dead host; wire it to the new host (UART + 3V3 + GND +
+  reset). Mind antenna: keep the M04 u.FL/embedded antenna path intact.
+- Bring up, confirm the CBKE session re-establishes with the meter (it should, the identity is on the
+  module), and confirm end-to-end data to Fly.
+- Keep the Pi local-API bypass as the fallback until the transplant proves stable.
+
+---
+
+## 6. Risks and mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Link is SPI, not UART | Low | Phase 3 detects it; re-channel to SPI and capture the same way |
+| Data is on UART1 while UART0 is a debug/ISP console | Medium | All 16 candidate lines tapped at once; keep the pair whose payload tracks meter reads |
+| Baud is nonstandard | Low | Measured from the narrowest pulse, not guessed |
+| Serial link is encrypted | Very low | RF is encrypted, not the local serial; if it is, fall back to host-storage repair (below) |
+| Host too dead to init the module | Rising over time | Do phases 1 to 4 **now**; steady-state alone may still suffice for read-only |
+| Flow control gates/splits bursts | Medium | Capture RTS/CTS on CH2 to interpret gaps |
+| Accidental short / driving a line | Low | Listen-only rig, verified with a meter before power-on; never enable analyzer outputs |
+| We damage the module during teardown | Low but costly | Non-destructive phases first; only phase 8 separates it, and only once the host is already dead |
+
+**Lower-effort alternative kept on the table:** if the serial route stalls, repairing/replacing the
+host's storage (if it is a discrete, reflashable part) and keeping Rainforest's firmware intact
+sidesteps the protocol work entirely. Worth a look during phase 1 (identify the storage chip).
+
+---
+
+## 7. Data handling and safety
+
+- **Captures may contain secrets.** Provisioning/rejoin traffic could carry link-layer key or
+  install-code material; the Eagle local API also leaks the Wi-Fi PSK in plaintext. Treat raw captures
+  and local-API dumps as **sensitive**: keep them off the repo, and **redact** before pasting into any
+  doc, issue, or artifact. The Install Code is a credential.
+- **No secrets in repo files** (standing project rule). The protocol spec records *format*, not keys.
+- **Electrical safety:** listen-only, common ground, 3.3 V verified before connecting. No line is ever
+  driven during capture.
+- **Production untouched:** the Pi bypass remains the primary uploader throughout phases 1 to 7; none
+  of this touches the live linknode.com path.
+
+## 8. Success criteria
+
+1. **Insurance met (phases 1 to 5):** a written, validated protocol spec that identifies a meter
+   reading in the stream and the request that produces it.
+2. **Build proven (phases 6 to 7):** a bench host that reads live values from the module matching the
+   local API within tolerance, sustained.
+3. **Transplant done (phase 8):** the module, on a new host, holds its meter session and ships data to
+   Fly end-to-end, with the Pi bypass retired to fallback.
+
+## 9. Rough effort
+
+- Phases 1 to 4: a focused weekend (most of it is careful teardown, tapping, and one good boot capture).
+- Phase 5: a few evenings, faster because of the known-plaintext anchors.
+- Phases 6 to 7: one to two weeks of part-time firmware work, mostly reusing the existing uploader.
+- Phase 8: a day, whenever the hardware forces it.
+
+## 10. Immediate next actions
+
+1. Confirm the **Saleae Logic 2 + 15-tool MCP** is reachable from the workstation next to the EAGLE,
+   and that Claude can enumerate the Logic 16 through it (dry run on a scrap signal).
+2. Get micro test hooks / 30 AWG wire (the only gear not on hand).
+3. Pull the **MS5168-Mxx datasheet pinout** (public) and pre-mark the module's `TXD0/RXD0/RTS0/CTS0`,
+   `TXD1/RXD1`, the SPI pins, `RSTN`, `GND`, and `3V3` before opening the case.
+4. Add a timestamped local-API logger mode (reuse `scripts/eagle_net.py`/`eagle_bypass.py`) to produce
+   the ground-truth table during capture.
+5. Schedule the teardown-and-capture session while the host still boots, in a session with the Saleae
+   MCP loaded so Claude can run the capture.
+
+## 11. References
+
+- [`eagle-200-hardware-notes.md`](eagle-200-hardware-notes.md) - the feasibility evidence this plan builds on.
+- FCC `2AC2E-68M04` (Meshreen JN5168 module, incl. public Test Report exhibit): https://fccid.io/2AC2E-68M04
+- NXP JN5168 (SoC; on-chip MAC+stack; UART/SPI): https://www.nxp.com/part/JN5168
+- Meshreen MS5168-Mxx (pinout, UART host interface): https://www.meshreen.com/ms5168-m04-2/
+- Seeed MeshBee cookbook (JN5168 module; AT/API/MCU host modes over UART): https://files.seeedstudio.com/wiki/Mesh_Bee/res/MeshBee_Cook_Book.pdf


### PR DESCRIPTION
Research log for the idea of keeping the meter-authenticated Zigbee radio and giving it a new host when the Eagle-200 finally dies (dodging the host-side storage wear).

**Key findings so far:**
- The Eagle-200 has **two separate Zigbee radios, two FCC IDs** — a modular architecture, exactly the partition the idea needs.
- `2AC2E-68M04` = Meshreen module built on the **NXP JN5168, a Zigbee SoC** (runs stack + app on-chip, UART/SPI host interface).
- `YCXRFA-W900` = Rainforest's own **Smart Control Module**.
- Likely mapping **HAN = JN5168 SoC** (pending internal-photo confirmation), which would put the transplant in the feasible camp.
- The current failure is host-side (filesystem/IPC); the meter link reads `Connected` 100%.

Records the open questions (which module is HAN, SoC-vs-NCP, host storage type) and the path to resolve them (FCC internal photos — automated fetch is bot-blocked, so a real browser or a teardown is needed). Living notes doc; will update as the investigation continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)