### PR TITLE
feat(eagle-bypass): make force (always-on) mode the default

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -107,15 +107,16 @@ sudo -u pi python3 /opt/eagle-bypass/eagle_bypass.py --print-stats
 
 ## Notes
 
-- **Always-on (current) vs. failover:** the Pi now runs `--force` (always-on),
-  because Rainforest removed the Eagle's own cloud uploader (at our request, to cut
-  device load), so the Pi is the sole source. If the device ever uploads on its own
-  again, drop `--force` and use `--stale-secs 90 --probe-secs 300` to return to
-  failover, else you'll get near-duplicate points.
+- **Always-on (default) vs. failover:** always-on is now the script's **default**
+  (no flag needed), because Rainforest removed the Eagle's own cloud uploader (at our
+  request, to cut device load), so the Pi is the sole source. If the device ever
+  uploads on its own again, add `--failover` (optionally with `--stale-secs 90
+  --probe-secs 300`) to return to failover, else you'll get near-duplicate points.
+  (`--force` is still accepted as a redundant no-op for backward compatibility.)
 - **What "device health" means now:** with the cloud uploader gone, the meaningful
   reliability signal is local-API read success (`read_failures` per cycle), i.e.
-  whether the Eagle answers the Pi. In `--force` mode the outage log (which keyed off
-  cloud staleness) no longer accrues. The other half of the picture is
+  whether the Eagle answers the Pi. In always-on (force) mode the outage log (which keyed
+  off cloud staleness) no longer accrues. The other half of the picture is
   `messages_failed` / `messages_sent`: how often the Fly endpoint rejects or fails to
   receive a transmission.
 - **Report rate (`--interval`, 30s).** The Eagle natively reports every ~8-10s; we

--- a/deploy/eagle-bypass.service
+++ b/deploy/eagle-bypass.service
@@ -25,9 +25,10 @@ EnvironmentFile=/etc/eagle-bypass.env
 # Always-on mode (the tuning the Pi runs): poll every 30s and ship every cycle.
 # Rainforest removed the Eagle's own cloud uploader (at our request, to cut device
 # load), so there is no real cloud path left to fail over from and the Pi is the
-# sole source. For the failover alternative (when the device still uploads on its
-# own), drop --force and use --stale-secs 90 --probe-secs 300 instead.
-ExecStart=/usr/bin/python3 /opt/eagle-bypass/eagle_bypass.py --interval 30 --force -v
+# sole source. Always-on (force) is now the script's DEFAULT, so no flag is needed.
+# For the failover alternative (when the device uploads on its own again), add
+# --failover (optionally with --stale-secs 90 --probe-secs 300).
+ExecStart=/usr/bin/python3 /opt/eagle-bypass/eagle_bypass.py --interval 30 -v
 
 Restart=always
 RestartSec=15

--- a/scripts/eagle_bypass.py
+++ b/scripts/eagle_bypass.py
@@ -20,7 +20,11 @@ FAILOVER, NOT REPLACEMENT (default)
     one cycle and watch: if the clock stays fresh while we're silent, Rainforest is
     back and we return to standby; if it goes stale again, we resume shipping.
 
-    --force        ship every cycle regardless (always-on / replace mode)
+    Force (always-on) is the DEFAULT: the Pi is the sole uploader, so it ships every
+    cycle. The failover behaviour above is opt-in via --failover, for the day the Eagle
+    uploads on its own again (else you'd get near-duplicate points).
+
+    --failover     ship only while the real cloud path is stale (the old default)
     --once         run a single cycle and exit (for cron/systemd timer)
     --dry-run      build and print the XML; do not POST
 
@@ -43,8 +47,8 @@ CREDENTIALS (from the environment; never logged)
         EAGLE_UPLOAD_USER      default 'eagle'  (matches EAGLE_USERNAME on Fly)
         EAGLE_UPLOAD_PASSWORD  the EAGLE_PASSWORD secret set on the Fly app
 
-Usage:  python eagle_bypass.py [--interval 30] [--stale-secs 90] [--probe-secs 300]
-                               [--force] [--once] [--dry-run] [-v]
+Usage:  python eagle_bypass.py [--interval 30] [--failover [--stale-secs 90]
+                               [--probe-secs 300]] [--once] [--dry-run] [-v]
 """
 
 import argparse
@@ -895,7 +899,12 @@ def main():
                     help="while active, pause uploads one cycle this often to test cloud recovery (default 300)")
     ap.add_argument("--heartbeat-secs", type=int, default=900,
                     help="ship a reliability/uptime heartbeat to the dashboard this often, any mode (default 900)")
-    ap.add_argument("--force", action="store_true", help="ship every cycle regardless of cloud health (always-on)")
+    ap.add_argument("--failover", action="store_true",
+                    help="failover mode: ship only while the real cloud path is stale. "
+                         "Default is force / always-on (the Pi is the sole uploader).")
+    # Force (always-on) is the default now; --force is accepted for backward compatibility
+    # (the old systemd unit passed it explicitly) but is redundant. --failover opts out.
+    ap.add_argument("--force", action="store_true", help=argparse.SUPPRESS)
     ap.add_argument("--once", action="store_true", help="run a single cycle and exit")
     ap.add_argument("--dry-run", action="store_true", help="build and print XML; do not POST")
     ap.add_argument("-v", "--verbose", action="store_true", help="log each upload's HTTP result")
@@ -904,6 +913,11 @@ def main():
     ap.add_argument("--report", action="store_true",
                     help="print a human-readable reliability/outage report and exit")
     args = ap.parse_args()
+
+    # Force (always-on) is the default; --failover is the explicit opt-out. The rest of
+    # the code keys off args.force, so derive it here. An explicit --force is a harmless
+    # no-op (default is already force); --failover always wins.
+    args.force = not args.failover
 
     if args.print_stats:
         print_stats()


### PR DESCRIPTION
## What

Make **force / always-on the default mode** of the Eagle bypass uploader.

Rainforest removed the Eagle's own cloud uploader (at our request, to reduce load on the failing
device), so the Pi is the sole source and there is no cloud path to fail over from. The tool's
defaults should reflect that.

## Changes

- `scripts/eagle_bypass.py`: force/always-on is now the default. New `--failover` flag opts back into
  the stale/probe behaviour (for the day the Eagle uploads on its own again). `--force` is kept as a
  redundant no-op for backward compatibility; `--failover` always wins.
- `deploy/eagle-bypass.service`: drops the now-redundant `--force` from `ExecStart`.
- `deploy/README.md` + script docstring: describe always-on as the default and `--failover` as the opt-out.

## Verified

`--help` shows `--failover`; parsing behaves: default → force on, `--failover` → off, `--force` → on,
`--failover --force` → failover wins. `py_compile` clean.

## Rollout note

No behaviour change on the Pi until the updated script + unit are manually deployed there; the running
service already operates in force mode via the old `--force` flag, which remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HiD4k8Y6XEjX8SFpNebRJ
