### PR TITLE
feat(dashboard): Meter Reads (24h), fresh-read completeness gauge

### DIFF
--- a/.claude/skills/linknode-stats/SKILL.md
+++ b/.claude/skills/linknode-stats/SKILL.md
@@ -107,14 +107,14 @@ curl -s https://linknode-eagle-monitor.fly.dev/health | python -m json.tool
 | Timestamp of last real meter data | **`last_update`** (root) | also at `monitor_stats.last_data_received`; there is **no** root `last_data_received` |
 | Last bypass heartbeat time | **`bypass_status.updated_at`** | **not** `received_at` (that key does not exist) |
 | Live uptime tile values | `bypass_status.data_uptime_pct` / `.device_uptime_pct` | shipped by the Pi heartbeat every 15 min |
-| Dashboard "Samples Today" (received/expected, rolling 24h) | `samples_24h.received` / `.expected` | the completeness gauge the dashboard shows; `.interval_s` and `.window_hours` included. `null` if the DB is unreachable |
-| Data points stored today (legacy counter) | `packets_today` (root) | successful InfluxDB writes since midnight UTC; still emitted but the dashboard now uses `samples_24h` |
+| Dashboard "Meter Reads (24h)" (received/expected, rolling 24h) | `reads_24h.received` / `.expected` | **fresh** reads passed on, the completeness gauge the dashboard shows; `.interval_s` and `.window_hours` included. `null` if the DB is unreachable |
+| Data points stored today (legacy counter) | `packets_today` (root) | successful InfluxDB writes since midnight UTC; still emitted but the dashboard now uses `reads_24h` |
 | Current power (W) | `current_power` (root) | last power reading |
 | Gap between last two points (ms) | `packet_interval_ms` (root) | |
 
 Root keys: `active_viewers, avg_24h, billing_period, bypass_status, cost_24h, current_power,
 last_update, max_24h, min_24h, monitor_stats, packet_interval_ms, packets_today, price_per_kwh,
-samples_24h`.
+reads_24h`.
 
 `monitor_stats` (the ingest service's internal counters) keys: `bypass_status, failed_writes,
 filtered_requests, last_data_received, last_power_reading, packet_interval_ms, packets_today,
@@ -123,7 +123,7 @@ packets_today_date, previous_data_received, start_time, successful_writes, total
 `bypass_status` keys (the Pi heartbeat, seconds spelled out): `data_uptime_pct, device_uptime_pct,
 observed_seconds, outage_count, readings_rescued, total_outage_seconds, updated_at,
 worst_outage_seconds, interval_s`. (The `*_seconds` names are the heartbeat XML's renames of the Pi's
-internal `*_s` fields. `interval_s` is the Pi's report cadence, used to size `samples_24h.expected`.)
+internal `*_s` fields. `interval_s` is the Pi's report cadence, used to size `reads_24h.expected`.)
 
 `/health`: `{influxdb_connected, status, uptime_seconds}`.
 
@@ -144,12 +144,15 @@ internal `*_s` fields. `interval_s` is the Pi's report cadence, used to size `sa
   but only data-bearing messages become InfluxDB writes; metadata-only messages (DeviceInfo,
   BillingPeriodList, etc.) are acknowledged without a write. So `packets_today` counts stored points,
   not raw messages.
-- **`samples_24h` is the completeness gauge the dashboard shows ("Samples Today").** `received` counts
-  stored `power_w` (InstantaneousDemand) points over a **rolling 24h** window (one per Pi cycle);
-  `expected` is `window / interval_s` (2880 at the 30s rate). `interval_s` comes from the Pi's
-  heartbeat, falling back to the `SAMPLE_INTERVAL_SEC` env then 30, so it auto-adjusts if the report
-  rate changes. `received` is clamped to `expected`, so e.g. `2878/2880` means two readings were missed
-  in the last 24h. Unlike `packets_today`, it is a sliding window, not a midnight-UTC reset.
+- **`reads_24h` is the completeness gauge the dashboard shows ("Meter Reads (24h)").** `received`
+  counts **fresh** `power_w` (InstantaneousDemand) points over a **rolling 24h** window; `expected` is
+  `window / interval_s` (2880 at the 30s rate, from the Pi heartbeat, else `SAMPLE_INTERVAL_SEC` env,
+  else 30). "Fresh" is enforced at the source: the Pi timestamps each reading with the meter's
+  **LastContact** time, so a cycle where the Eagle did not respond (nothing shipped) or returned stale
+  data (same LastContact -> the point overwrites rather than adds) does not increment the count.
+  `received` is clamped to `expected`, so `2878/2880` means two of the last 24h's scheduled 30s reads
+  were missed or stale. Sliding window, not a midnight-UTC reset. Contrast `packets_today`, which counts
+  every successful write (including stale re-sends) since midnight UTC.
 - **The heartbeat is deliberately out-of-band.** The collector stashes `bypass_status` but does
   **not** touch `last_update` / `last_data_received`, so a heartbeat cannot masquerade as fresh meter
   data and suppress a real staleness alert. Judge freshness by `last_update`, judge the Pi's

--- a/.claude/skills/linknode-stats/SKILL.md
+++ b/.claude/skills/linknode-stats/SKILL.md
@@ -107,12 +107,14 @@ curl -s https://linknode-eagle-monitor.fly.dev/health | python -m json.tool
 | Timestamp of last real meter data | **`last_update`** (root) | also at `monitor_stats.last_data_received`; there is **no** root `last_data_received` |
 | Last bypass heartbeat time | **`bypass_status.updated_at`** | **not** `received_at` (that key does not exist) |
 | Live uptime tile values | `bypass_status.data_uptime_pct` / `.device_uptime_pct` | shipped by the Pi heartbeat every 15 min |
-| Data points stored today | `packets_today` (root) | successful InfluxDB writes; resets midnight UTC |
+| Dashboard "Samples Today" (received/expected, rolling 24h) | `samples_24h.received` / `.expected` | the completeness gauge the dashboard shows; `.interval_s` and `.window_hours` included. `null` if the DB is unreachable |
+| Data points stored today (legacy counter) | `packets_today` (root) | successful InfluxDB writes since midnight UTC; still emitted but the dashboard now uses `samples_24h` |
 | Current power (W) | `current_power` (root) | last power reading |
 | Gap between last two points (ms) | `packet_interval_ms` (root) | |
 
 Root keys: `active_viewers, avg_24h, billing_period, bypass_status, cost_24h, current_power,
-last_update, max_24h, min_24h, monitor_stats, packet_interval_ms, packets_today, price_per_kwh`.
+last_update, max_24h, min_24h, monitor_stats, packet_interval_ms, packets_today, price_per_kwh,
+samples_24h`.
 
 `monitor_stats` (the ingest service's internal counters) keys: `bypass_status, failed_writes,
 filtered_requests, last_data_received, last_power_reading, packet_interval_ms, packets_today,
@@ -120,8 +122,8 @@ packets_today_date, previous_data_received, start_time, successful_writes, total
 
 `bypass_status` keys (the Pi heartbeat, seconds spelled out): `data_uptime_pct, device_uptime_pct,
 observed_seconds, outage_count, readings_rescued, total_outage_seconds, updated_at,
-worst_outage_seconds`. (These `*_seconds` names are the heartbeat XML's renames of the Pi's internal
-`*_s` fields.)
+worst_outage_seconds, interval_s`. (The `*_seconds` names are the heartbeat XML's renames of the Pi's
+internal `*_s` fields. `interval_s` is the Pi's report cadence, used to size `samples_24h.expected`.)
 
 `/health`: `{influxdb_connected, status, uptime_seconds}`.
 
@@ -142,6 +144,12 @@ worst_outage_seconds`. (These `*_seconds` names are the heartbeat XML's renames 
   but only data-bearing messages become InfluxDB writes; metadata-only messages (DeviceInfo,
   BillingPeriodList, etc.) are acknowledged without a write. So `packets_today` counts stored points,
   not raw messages.
+- **`samples_24h` is the completeness gauge the dashboard shows ("Samples Today").** `received` counts
+  stored `power_w` (InstantaneousDemand) points over a **rolling 24h** window (one per Pi cycle);
+  `expected` is `window / interval_s` (2880 at the 30s rate). `interval_s` comes from the Pi's
+  heartbeat, falling back to the `SAMPLE_INTERVAL_SEC` env then 30, so it auto-adjusts if the report
+  rate changes. `received` is clamped to `expected`, so e.g. `2878/2880` means two readings were missed
+  in the last 24h. Unlike `packets_today`, it is a sliding window, not a midnight-UTC reset.
 - **The heartbeat is deliberately out-of-band.** The collector stashes `bypass_status` but does
   **not** touch `last_update` / `last_data_received`, so a heartbeat cannot masquerade as fresh meter
   data and suppress a real staleness alert. Judge freshness by `last_update`, judge the Pi's

--- a/fly/eagle-monitor/app.py
+++ b/fly/eagle-monitor/app.py
@@ -400,6 +400,7 @@ def parse_eagle_xml(xml_data):
                 'total_outage_seconds': _num('TotalOutageSeconds', int),
                 'worst_outage_seconds': _num('WorstOutageSeconds', int),
                 'readings_rescued': _num('ReadingsRescued', int),
+                'interval_s': _num('IntervalSeconds', int),
             }
 
         # 3. TimeCluster - Time synchronization
@@ -701,6 +702,9 @@ def get_stats():
         'active_viewers': active_viewers,
         'packet_interval_ms': stats.get('packet_interval_ms'),
         'packets_today': stats.get('packets_today', 0),
+        # Rolling 24h completeness: readings received vs expected at the report rate.
+        # Populated from InfluxDB below; None if the DB is unreachable.
+        'samples_24h': None,
         # Live uptime from the Pi bypass heartbeat (None until the first arrives).
         'bypass_status': stats.get('bypass_status'),
         'monitor_stats': stats,
@@ -743,6 +747,27 @@ def get_stats():
             avg_result = query_api.query(org=INFLUXDB_ORG, query=avg_query)
             if avg_result and avg_result[0].records:
                 result['avg_24h'] = avg_result[0].records[0].get_value()
+
+            # Rolling-window completeness: how many meter readings actually arrived vs
+            # how many should have at the report rate. "received" = stored power_w
+            # (InstantaneousDemand) points in the window; "expected" = window / interval.
+            # Interval source, in priority: the Pi's own heartbeat, then SAMPLE_INTERVAL_SEC
+            # env, then 30s. This auto-adjusts if the Pi's report rate changes.
+            count_query = query + '|> group() |> count()'
+            count_result = query_api.query(org=INFLUXDB_ORG, query=count_query)
+            received = 0
+            if count_result and count_result[0].records:
+                received = int(count_result[0].records[0].get_value() or 0)
+            bypass = stats.get('bypass_status') or {}
+            interval_s = bypass.get('interval_s') or int(os.getenv('SAMPLE_INTERVAL_SEC', '30'))
+            interval_s = interval_s if interval_s and interval_s > 0 else 30
+            expected = round(hours * 3600 / interval_s)
+            result['samples_24h'] = {
+                'received': min(received, expected),   # clamp jitter so it never exceeds 100%
+                'expected': expected,
+                'interval_s': interval_s,
+                'window_hours': hours,
+            }
 
             # Get current electricity rate from InfluxDB (reported by Eagle from utility)
             price_query = f'''

--- a/fly/eagle-monitor/app.py
+++ b/fly/eagle-monitor/app.py
@@ -702,9 +702,9 @@ def get_stats():
         'active_viewers': active_viewers,
         'packet_interval_ms': stats.get('packet_interval_ms'),
         'packets_today': stats.get('packets_today', 0),
-        # Rolling 24h completeness: readings received vs expected at the report rate.
-        # Populated from InfluxDB below; None if the DB is unreachable.
-        'samples_24h': None,
+        # Rolling 24h completeness: fresh meter reads received vs expected at the report
+        # rate. Populated from InfluxDB below; None if the DB is unreachable.
+        'reads_24h': None,
         # Live uptime from the Pi bypass heartbeat (None until the first arrives).
         'bypass_status': stats.get('bypass_status'),
         'monitor_stats': stats,
@@ -748,11 +748,14 @@ def get_stats():
             if avg_result and avg_result[0].records:
                 result['avg_24h'] = avg_result[0].records[0].get_value()
 
-            # Rolling-window completeness: how many meter readings actually arrived vs
-            # how many should have at the report rate. "received" = stored power_w
-            # (InstantaneousDemand) points in the window; "expected" = window / interval.
-            # Interval source, in priority: the Pi's own heartbeat, then SAMPLE_INTERVAL_SEC
-            # env, then 30s. This auto-adjusts if the Pi's report rate changes.
+            # Rolling-window completeness: how many FRESH meter reads arrived vs how many
+            # should have at the report rate. "received" = distinct stored power_w
+            # (InstantaneousDemand) points in the window; because the Pi timestamps each
+            # reading with the meter's LastContact time, a cycle where the Eagle did not
+            # respond (nothing shipped) or returned stale data (same LastContact -> same
+            # point, overwritten) does not add a point, so it does not count. "expected" =
+            # window / interval; interval comes from the Pi heartbeat, else SAMPLE_INTERVAL_SEC
+            # env, else 30s, so it auto-adjusts if the report rate changes.
             count_query = query + '|> group() |> count()'
             count_result = query_api.query(org=INFLUXDB_ORG, query=count_query)
             received = 0
@@ -762,7 +765,7 @@ def get_stats():
             interval_s = bypass.get('interval_s') or int(os.getenv('SAMPLE_INTERVAL_SEC', '30'))
             interval_s = interval_s if interval_s and interval_s > 0 else 30
             expected = round(hours * 3600 / interval_s)
-            result['samples_24h'] = {
+            result['reads_24h'] = {
                 'received': min(received, expected),   # clamp jitter so it never exceeds 100%
                 'expected': expected,
                 'interval_s': interval_s,

--- a/fly/web/index.html
+++ b/fly/web/index.html
@@ -1214,9 +1214,9 @@
                             </div>
                         </div>
                         <div class="api-status-item">
-                            <span class="api-name" title="Meter samples received from the Pi in the last 24 hours vs. the number expected at the current report rate">📊 Samples Today</span>
+                            <span class="api-name" title="Fresh meter readings the Pi passed on from the Eagle in the last 24 hours vs. the number expected at the report rate. A 30s cycle where the Eagle did not respond, or returned stale (unchanged) data, does not count.">📊 Meter Reads (24h)</span>
                             <div class="api-status">
-                                <span id="samples-today" style="font-weight: 600; color: var(--text-primary);">--</span>
+                                <span id="meter-reads" style="font-weight: 600; color: var(--text-primary);">--</span>
                             </div>
                         </div>
                         <div class="api-status-item">
@@ -1863,16 +1863,16 @@
                             document.getElementById('active-viewers-count').textContent = data.active_viewers;
                         }
 
-                        // Update samples today: readings received vs expected over the last 24h
-                        const samplesEl = document.getElementById('samples-today');
-                        if (samplesEl) {
-                            const s = data.samples_24h;
-                            if (s && s.expected) {
-                                samplesEl.textContent =
-                                    `${s.received.toLocaleString()}/${s.expected.toLocaleString()}`;
+                        // Update Meter Reads (24h): fresh reads received vs expected over the last 24h
+                        const readsEl = document.getElementById('meter-reads');
+                        if (readsEl) {
+                            const r = data.reads_24h;
+                            if (r && r.expected) {
+                                readsEl.textContent =
+                                    `${r.received.toLocaleString()}/${r.expected.toLocaleString()}`;
                             } else if (data.packets_today !== undefined) {
-                                // Fallback until the backend reports samples_24h (e.g. DB unreachable)
-                                samplesEl.textContent = data.packets_today.toLocaleString();
+                                // Fallback until the backend reports reads_24h (e.g. DB unreachable)
+                                readsEl.textContent = data.packets_today.toLocaleString();
                             }
                         }
 

--- a/fly/web/index.html
+++ b/fly/web/index.html
@@ -1214,9 +1214,9 @@
                             </div>
                         </div>
                         <div class="api-status-item">
-                            <span class="api-name">📦 Packets Today</span>
+                            <span class="api-name" title="Meter samples received from the Pi in the last 24 hours vs. the number expected at the current report rate">📊 Samples Today</span>
                             <div class="api-status">
-                                <span id="packets-today" style="font-weight: 600; color: var(--text-primary);">--</span>
+                                <span id="samples-today" style="font-weight: 600; color: var(--text-primary);">--</span>
                             </div>
                         </div>
                         <div class="api-status-item">
@@ -1226,7 +1226,7 @@
                             </div>
                         </div>
                         <div class="api-status-item">
-                            <span class="api-name">⏱️ Packet Interval</span>
+                            <span class="api-name">⏱️ Sample Interval</span>
                             <div class="api-status">
                                 <span id="packet-interval" style="font-weight: 600; color: var(--text-primary);">--</span>
                             </div>
@@ -1863,9 +1863,17 @@
                             document.getElementById('active-viewers-count').textContent = data.active_viewers;
                         }
 
-                        // Update packets today
-                        if (data.packets_today !== undefined) {
-                            document.getElementById('packets-today').textContent = data.packets_today.toLocaleString();
+                        // Update samples today: readings received vs expected over the last 24h
+                        const samplesEl = document.getElementById('samples-today');
+                        if (samplesEl) {
+                            const s = data.samples_24h;
+                            if (s && s.expected) {
+                                samplesEl.textContent =
+                                    `${s.received.toLocaleString()}/${s.expected.toLocaleString()}`;
+                            } else if (data.packets_today !== undefined) {
+                                // Fallback until the backend reports samples_24h (e.g. DB unreachable)
+                                samplesEl.textContent = data.packets_today.toLocaleString();
+                            }
                         }
 
                         // Update packet interval (time between Eagle-200 packets)

--- a/scripts/eagle_bypass.py
+++ b/scripts/eagle_bypass.py
@@ -228,13 +228,31 @@ def _hexts():
     return f"0x{int(time.time()) - ZIGBEE_EPOCH_OFFSET:x}"
 
 
-def msg_demand(kw, meter_mac):
+def _reading_ts(link):
+    """Reading timestamp (Zigbee-epoch hex) from the meter's LastContact, i.e. when the
+    Eagle actually last heard from the meter, NOT wall-clock now. This is what makes a
+    reading count as *fresh*: if the Eagle's daemon hangs it keeps returning the same
+    LastContact, so successive ships collapse onto the same time-series point instead of
+    looking like new readings. LastContact is raw Unix; the collector re-adds the epoch
+    offset, so subtract it here (same convention as _hexts). Falls back to now if the
+    Eagle gave us no usable LastContact."""
+    lc = link[1] if link else None
+    if lc:
+        try:
+            unix = int(lc, 16) if str(lc).startswith("0x") else int(lc)
+            return f"0x{unix - ZIGBEE_EPOCH_OFFSET:x}"
+        except (ValueError, TypeError):
+            pass
+    return _hexts()
+
+
+def msg_demand(kw, meter_mac, ts=None):
     raw = max(0, round(kw * 1000))  # watts; mult=1 div=1000 -> collector power_w = raw
     return (
         "<rainforest><InstantaneousDemand>"
         f"<DeviceMacId>{DEVICE_MAC}</DeviceMacId>"
         f"<MeterMacId>{meter_mac}</MeterMacId>"
-        f"<TimeStamp>{_hexts()}</TimeStamp>"
+        f"<TimeStamp>{ts or _hexts()}</TimeStamp>"
         f"<Demand>0x{raw:08x}</Demand>"
         "<Multiplier>0x00000001</Multiplier>"
         "<Divisor>0x000003e8</Divisor>"
@@ -242,13 +260,13 @@ def msg_demand(kw, meter_mac):
     )
 
 
-def msg_summation(kwh, meter_mac):
+def msg_summation(kwh, meter_mac, ts=None):
     raw = max(0, round(kwh * 1000))  # Wh; mult=1 div=1000 -> collector kWh = raw/1000
     return (
         "<rainforest><CurrentSummationDelivered>"
         f"<DeviceMacId>{DEVICE_MAC}</DeviceMacId>"
         f"<MeterMacId>{meter_mac}</MeterMacId>"
-        f"<TimeStamp>{_hexts()}</TimeStamp>"
+        f"<TimeStamp>{ts or _hexts()}</TimeStamp>"
         f"<SummationDelivered>0x{raw:012x}</SummationDelivered>"
         "<Multiplier>0x00000001</Multiplier>"
         "<Divisor>0x000003e8</Divisor>"
@@ -810,11 +828,14 @@ def ship(stats, dry_run=False, verbose=False):
         return False
     meter_mac = meter_mac or METER_MAC_FALLBACK
 
+    # Stamp readings with the meter's real last-contact time, so a frozen Eagle
+    # (LastContact not advancing) does not masquerade as a stream of fresh readings.
+    ts = _reading_ts(link)
     outbox = []
     if "demand_kw" in readings:
-        outbox.append(("demand", msg_demand(readings["demand_kw"], meter_mac)))
+        outbox.append(("demand", msg_demand(readings["demand_kw"], meter_mac, ts)))
     if "summation_kwh" in readings:
-        outbox.append(("summation", msg_summation(readings["summation_kwh"], meter_mac)))
+        outbox.append(("summation", msg_summation(readings["summation_kwh"], meter_mac, ts)))
     if "price" in readings:
         outbox.append(("price", msg_price(readings["price"], meter_mac)))
 

--- a/scripts/eagle_bypass.py
+++ b/scripts/eagle_bypass.py
@@ -287,6 +287,7 @@ def msg_bypass_status(snap):
         f"<TotalOutageSeconds>{num(snap.get('total_outage_s'))}</TotalOutageSeconds>"
         f"<WorstOutageSeconds>{num(snap.get('worst_outage_s'))}</WorstOutageSeconds>"
         f"<ReadingsRescued>{num(snap.get('readings_rescued'))}</ReadingsRescued>"
+        f"<IntervalSeconds>{num(snap.get('interval_s'))}</IntervalSeconds>"
         "</BypassStatus></rainforest>"
     )
 
@@ -548,6 +549,7 @@ class Stats:
         # watching (no cycles ran), so it correctly does not count.
         obs = d.get("cycles", 0) * self.interval
         d["observed_s"] = obs
+        d["interval_s"] = self.interval   # report our cadence so the site can size "expected"
         n = d.get("outage_count", 0)
         completed = sum(d.get("duration_buckets", []))   # outages with a real duration
         d["mean_outage_s"] = round(d["total_outage_s"] / completed) if completed else None


### PR DESCRIPTION
## What

Replace the opaque **"Packets Today"** tile with **"Meter Reads (24h)"**, shown as a rolling 24-hour
**received / expected** gauge (e.g. `2878/2880`) that counts only **fresh** reads the Pi passed on
from the Eagle.

## Why

"Packets Today" read like network packets, actually counted stored writes, and reset at midnight UTC.
Worse, it (and the chart) counted **stale** data: when the Eagle's daemon hangs it keeps returning the
same frozen reading, and the Pi was stamping each with wall-clock "now", so a dead meter looked like a
live stream. "2878/2880" answers the real question: of the 2880 scheduled 30s reads in the last 24h,
how many actually delivered fresh meter data?

## How "fresh" is enforced

The Eagle exposes freshness as `LastContact` (a Unix epoch that advances only when it hears from the
meter; confirmed live: +16s over a 13s gap, with the value changing). The Pi now stamps each reading
with `LastContact` (converted to the Zigbee epoch the collector expects) instead of "now":

- **Fresh** read → `LastContact` advanced → distinct InfluxDB point → counts.
- **Stale** read → same `LastContact` → same point (overwrite) → does **not** count.
- **No response** → nothing shipped → no point → does **not** count.
- Missing/garbage `LastContact` → falls back to "now" (previous behaviour).

`reads_24h.received` is then just the count of distinct `power_w` points over the window; `expected` =
`window / interval`, with the interval from the Pi heartbeat (`IntervalSeconds`, added here), else the
`SAMPLE_INTERVAL_SEC` env, else 30s, so it auto-adjusts if the report rate changes. `received` is
clamped to `expected`.

## Changes

- `scripts/eagle_bypass.py`: stamp readings with the meter's `LastContact` time; heartbeat reports its
  poll cadence (`IntervalSeconds`).
- `fly/eagle-monitor/app.py`: `/api/stats` gains `reads_24h {received, expected, interval_s,
  window_hours}`; parse `IntervalSeconds` from the heartbeat.
- `fly/web/index.html`: tile → "Meter Reads (24h)" with an explanatory tooltip; "Packet Interval" →
  "Sample Interval"; emoji swap.
- `.claude/skills/linknode-stats`: documents `reads_24h` and the fresh-read semantics.

## Behavioural note (please review)

This changes stored telemetry timestamps from ship-time to **meter-read time** (`LastContact`). In
normal operation points move by <30s, so charts are essentially unchanged; during an Eagle stall the
time-series now correctly **stops advancing** instead of plotting a frozen value as fresh. Staleness/
Pushover alerting is unaffected (it keys off wall-clock write time, not point time). `packets_today` is
kept in the API (legacy) but no longer drives the dashboard.

**Merging touches `fly/**`, so it will trigger a Fly deploy** (web + eagle-monitor). The `LastContact`
timestamping only takes effect once the Pi script is manually redeployed; until then the monitor's
30s-fallback `expected` is correct and readings keep flowing as before.

## Verified

Both Python files compile; `LastContact` round-trips through the collector's epoch math to the correct
real time (safety net not tripped); stale `LastContact` yields an identical timestamp (collapses), a
fresh one differs; no test references the old label/id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HiD4k8Y6XEjX8SFpNebRJ
