### PR TITLE
fix(reads): size expected from measured cycle period (~35s), not nominal 30s

### DIFF
--- a/.claude/skills/linknode-stats/SKILL.md
+++ b/.claude/skills/linknode-stats/SKILL.md
@@ -107,7 +107,7 @@ curl -s https://linknode-eagle-monitor.fly.dev/health | python -m json.tool
 | Timestamp of last real meter data | **`last_update`** (root) | also at `monitor_stats.last_data_received`; there is **no** root `last_data_received` |
 | Last bypass heartbeat time | **`bypass_status.updated_at`** | **not** `received_at` (that key does not exist) |
 | Live uptime tile values | `bypass_status.data_uptime_pct` / `.device_uptime_pct` | shipped by the Pi heartbeat every 15 min |
-| Dashboard "Meter Reads (24h)" (received/expected, rolling 24h) | `reads_24h.received` / `.expected` | **fresh** reads passed on, the completeness gauge the dashboard shows; `.interval_s` and `.window_hours` included. `null` if the DB is unreachable |
+| Dashboard "Meter Reads (24h)" (received/expected, rolling 24h) | `reads_24h.received` / `.expected` | **fresh** reads passed on, the completeness gauge the dashboard shows; `.period_s` (the measured cycle time used to size `expected`) and `.window_hours` included. `null` if the DB is unreachable |
 | Data points stored today (legacy counter) | `packets_today` (root) | successful InfluxDB writes since midnight UTC; still emitted but the dashboard now uses `reads_24h` |
 | Current power (W) | `current_power` (root) | last power reading |
 | Gap between last two points (ms) | `packet_interval_ms` (root) | |
@@ -122,8 +122,10 @@ packets_today_date, previous_data_received, start_time, successful_writes, total
 
 `bypass_status` keys (the Pi heartbeat, seconds spelled out): `data_uptime_pct, device_uptime_pct,
 observed_seconds, outage_count, readings_rescued, total_outage_seconds, updated_at,
-worst_outage_seconds, interval_s`. (The `*_seconds` names are the heartbeat XML's renames of the Pi's
-internal `*_s` fields. `interval_s` is the Pi's report cadence, used to size `reads_24h.expected`.)
+worst_outage_seconds, interval_s, cycle_period_s`. (The `*_seconds` names are the heartbeat XML's
+renames of the Pi's internal `*_s` fields. `interval_s` is the nominal `--interval` (30). `cycle_period_s`
+is the Pi's **measured** true cycle time, EMA of sleep + per-cycle work, ~35s, and is what actually
+sizes `reads_24h.expected`.)
 
 `/health`: `{influxdb_connected, status, uptime_seconds}`.
 
@@ -146,13 +148,19 @@ internal `*_s` fields. `interval_s` is the Pi's report cadence, used to size `re
   not raw messages.
 - **`reads_24h` is the completeness gauge the dashboard shows ("Meter Reads (24h)").** `received`
   counts **fresh** `power_w` (InstantaneousDemand) points over a **rolling 24h** window; `expected` is
-  `window / interval_s` (2880 at the 30s rate, from the Pi heartbeat, else `SAMPLE_INTERVAL_SEC` env,
-  else 30). "Fresh" is enforced at the source: the Pi timestamps each reading with the meter's
-  **LastContact** time, so a cycle where the Eagle did not respond (nothing shipped) or returned stale
-  data (same LastContact -> the point overwrites rather than adds) does not increment the count.
-  `received` is clamped to `expected`, so `2878/2880` means two of the last 24h's scheduled 30s reads
-  were missed or stale. Sliding window, not a midnight-UTC reset. Contrast `packets_today`, which counts
-  every successful write (including stale re-sends) since midnight UTC.
+  `window / period_s`. **`period_s` is the Pi's MEASURED cycle time (~35s), not the nominal `--interval`
+  (30s).** The real cadence is slower than the interval because each cycle also does work (two Eagle API
+  calls + three POSTs) before the `--interval` sleep, so the true max is ~2469/24h, not 2880. Sizing
+  `expected` off the nominal 30s produced a phantom ~15% shortfall (a flat ~85% at every window size was
+  the tell); the measured period fixes it. "Fresh" is enforced at the source: the Pi timestamps each
+  reading with the meter's **LastContact** time, so a cycle where the Eagle did not respond (nothing
+  shipped) or returned stale data (same LastContact -> the point overwrites rather than adds) does not
+  increment the count. `received` is clamped to `expected`. Sliding window, not a midnight-UTC reset.
+  Contrast `packets_today`, which counts every successful write (including stale re-sends) since midnight UTC.
+- **"Meter Reads" vs the "Data Uptime" tile.** They measure different things and can diverge. Data
+  Uptime = the Pi's `data_availability_pct` = it shipped something each cycle (in force mode ~100%
+  unless the Eagle stops responding), and it does NOT drop for stale-but-answered reads. Meter Reads
+  drops for both no-response and stale. When healthy both sit near 100%.
 - **The heartbeat is deliberately out-of-band.** The collector stashes `bypass_status` but does
   **not** touch `last_update` / `last_data_received`, so a heartbeat cannot masquerade as fresh meter
   data and suppress a real staleness alert. Judge freshness by `last_update`, judge the Pi's

--- a/fly/eagle-monitor/app.py
+++ b/fly/eagle-monitor/app.py
@@ -401,6 +401,7 @@ def parse_eagle_xml(xml_data):
                 'worst_outage_seconds': _num('WorstOutageSeconds', int),
                 'readings_rescued': _num('ReadingsRescued', int),
                 'interval_s': _num('IntervalSeconds', int),
+                'cycle_period_s': _num('CyclePeriodSeconds', float),
             }
 
         # 3. TimeCluster - Time synchronization
@@ -754,21 +755,24 @@ def get_stats():
             # reading with the meter's LastContact time, a cycle where the Eagle did not
             # respond (nothing shipped) or returned stale data (same LastContact -> same
             # point, overwritten) does not add a point, so it does not count. "expected" =
-            # window / interval; interval comes from the Pi heartbeat, else SAMPLE_INTERVAL_SEC
-            # env, else 30s, so it auto-adjusts if the report rate changes.
+            # window / period, where period is the Pi's MEASURED true cycle time (sleep +
+            # per-cycle work, ~35s at a nominal 30s interval), else the nominal interval,
+            # else SAMPLE_INTERVAL_SEC env, else 30. Using the measured period avoids a
+            # phantom shortfall from counting against an unachievable nominal rate.
             count_query = query + '|> group() |> count()'
             count_result = query_api.query(org=INFLUXDB_ORG, query=count_query)
             received = 0
             if count_result and count_result[0].records:
                 received = int(count_result[0].records[0].get_value() or 0)
             bypass = stats.get('bypass_status') or {}
-            interval_s = bypass.get('interval_s') or int(os.getenv('SAMPLE_INTERVAL_SEC', '30'))
-            interval_s = interval_s if interval_s and interval_s > 0 else 30
-            expected = round(hours * 3600 / interval_s)
+            period_s = (bypass.get('cycle_period_s') or bypass.get('interval_s')
+                        or float(os.getenv('SAMPLE_INTERVAL_SEC', '30')))
+            period_s = period_s if period_s and period_s > 0 else 30.0
+            expected = round(hours * 3600 / period_s)
             result['reads_24h'] = {
                 'received': min(received, expected),   # clamp jitter so it never exceeds 100%
                 'expected': expected,
-                'interval_s': interval_s,
+                'period_s': round(period_s, 1),
                 'window_hours': hours,
             }
 

--- a/scripts/eagle_bypass.py
+++ b/scripts/eagle_bypass.py
@@ -306,6 +306,7 @@ def msg_bypass_status(snap):
         f"<WorstOutageSeconds>{num(snap.get('worst_outage_s'))}</WorstOutageSeconds>"
         f"<ReadingsRescued>{num(snap.get('readings_rescued'))}</ReadingsRescued>"
         f"<IntervalSeconds>{num(snap.get('interval_s'))}</IntervalSeconds>"
+        f"<CyclePeriodSeconds>{num(snap.get('cycle_period_s'))}</CyclePeriodSeconds>"
         "</BypassStatus></rainforest>"
     )
 
@@ -396,7 +397,7 @@ class Stats:
     """In-RAM counters, mirrored to a live RAM file each cycle and checkpointed to
     two CRC-protected flash copies hourly. On start, restore from a valid copy."""
 
-    SCHEMA = 3
+    SCHEMA = 4
 
     def __init__(self, runtime_dir, state_dir):
         self.live_path = os.path.join(runtime_dir, "stats.json") if runtime_dir else None
@@ -428,6 +429,8 @@ class Stats:
             "first_outage_at": None, "last_outage_end": None,
             "outages_by_hour": [0] * 24, "duration_buckets": [0] * 5,
             "observed_s": 0, "readings_rescued": 0,
+            # Measured true cycle period (EMA); None until a couple of cycles run.
+            "cycle_period_s": None,
             # ---- meter (Zigbee) link health, from device_list ----
             "meter_status": None, "meter_last_contact": None,
             "meter_link_checks": 0, "meter_not_connected": 0,
@@ -690,6 +693,12 @@ class Stats:
         if co:
             co["read_fails"] += 1
 
+    def note_period(self, dt):
+        """Smooth (EMA) the measured true cycle period, so the site can size expected
+        reads from the real cadence (~interval + work) rather than the nominal interval."""
+        prev = self.d.get("cycle_period_s")
+        self.d["cycle_period_s"] = round(dt if prev is None else 0.1 * dt + 0.9 * prev, 2)
+
     def note_meter_link(self, status, last_contact):
         """Record the Eagle<->meter Zigbee link state seen in device_list."""
         self.d["meter_link_checks"] += 1
@@ -889,8 +898,20 @@ def run_loop(args, stats):
     last_probe = time.monotonic()
     stats.interval = args.interval   # so observed_s accrues real wall time per cycle
     last_heartbeat = None            # force one on the first cycle so the site populates fast
+    last_tick = None                 # for measuring the true cycle period (sleep + work)
 
     while True:
+        # Measure the real cycle period top-to-top: it is --interval of sleep PLUS the
+        # per-cycle work (two Eagle API calls + the uploads), so it runs a few seconds
+        # longer than --interval. The dashboard uses this, not the nominal interval, to
+        # size how many reads to expect. Reject absurd gaps (suspend / long hang).
+        tick = time.monotonic()
+        if last_tick is not None:
+            dt = tick - last_tick
+            if dt <= args.interval * 4:
+                stats.note_period(dt)
+        last_tick = tick
+
         age = fly_age_seconds()
         age_str = "unknown" if age is None else f"{round(age)}s"
         mode = "active"           # refined below for the standby/probing cases


### PR DESCRIPTION
## What

Fix the "Meter Reads (24h)" gauge, which read a flat **~85%** while the Eagle was healthy. It was a
denominator bug, not data loss.

## Root cause

`expected` was `86400 / --interval` = `86400 / 30` = 2880. But `--interval` is only the **sleep**
between cycles; each cycle also does ~5s of work first (two Eagle API round-trips + three POSTs), so
the real cadence is **~35s** (measured 34-37s from the ship log, median 35). The true max is
**~2469 reads/24h**, and `received` was 2449, i.e. **~99% complete**. The flat ~85% at *every* window
size (1h/2h/6h/12h/24h all ≈85%) confirmed a uniform denominator error rather than a lumpy outage.

This also explains the tile the user flagged: **"Data Uptime 100%" was correct** (the Pi reads and
ships every cycle, `read_failures: 0`); the misleading number was Meter Reads, from this bug.

## Fix

The Pi now measures its **true cycle period** (EMA of the top-to-top loop time, absurd suspend/hang
gaps rejected) and reports it in the heartbeat as `CyclePeriodSeconds`. The collector sizes `expected`
off that, with fallbacks: measured period → nominal interval → `SAMPLE_INTERVAL_SEC` env → 30. It is
self-correcting: if the Eagle gets slower to answer or the interval changes, the denominator tracks it.

- `scripts/eagle_bypass.py`: measure period in `run_loop`; `Stats.note_period` EMA; `cycle_period_s`
  added to `_fresh` (SCHEMA 3→4, backfilled on restore); heartbeat sends `CyclePeriodSeconds`.
- `fly/eagle-monitor/app.py`: parse `CyclePeriodSeconds`; `reads_24h.expected` now uses the measured
  `period_s` (the field renamed from `interval_s`).
- `.claude/skills/linknode-stats`: documents `period_s` / `cycle_period_s` and the Meter-Reads vs
  Data-Uptime distinction.

## Verified

Both Python files compile; the EMA converges 30→~35 over ~12 cycles (expected ~2472 → ~99% against the
current 2449). The frontend reads `received`/`expected` only, so no JS change was needed.

## Rollout

Merging deploys the collector (touches `fly/**`). The corrected denominator only fully lands once the
**Pi is also redeployed** (so it sends `CyclePeriodSeconds`); until then the collector falls back to the
nominal 30 and the tile keeps showing the ~85%. I'll redeploy the Pi after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HiD4k8Y6XEjX8SFpNebRJ
