### PR TITLE
ui(dashboard): meter-reads % on big tile; simplify Meter Reads tile

### DIFF
--- a/fly/web/index.html
+++ b/fly/web/index.html
@@ -1214,7 +1214,7 @@
                             </div>
                         </div>
                         <div class="api-status-item">
-                            <span class="api-name" title="Fresh meter readings the Pi passed on from the Eagle in the last 24 hours vs. the number expected at the report rate. A 30s cycle where the Eagle did not respond, or returned stale (unchanged) data, does not count.">📊 Meter Reads (24h)</span>
+                            <span class="api-name" title="Fresh meter readings the Pi passed on from the Eagle in the last 24 hours vs. the number expected at the report rate. A 30s cycle where the Eagle did not respond, or returned stale (unchanged) data, does not count.">📊 Meter Reads</span>
                             <div class="api-status">
                                 <span id="meter-reads" style="font-weight: 600; color: var(--text-primary);">--</span>
                             </div>
@@ -1802,7 +1802,12 @@
                             du.textContent = b.data_uptime_pct.toFixed(1) + '%';
                         }
                         if (b.device_uptime_pct !== null && b.device_uptime_pct !== undefined) {
-                            dev.textContent = 'device ' + Math.round(b.device_uptime_pct) + '%';
+                            let sub = 'device ' + Math.round(b.device_uptime_pct) + '%';
+                            const r = data.reads_24h;
+                            if (r && r.expected) {
+                                sub += ' · reads ' + (100 * r.received / r.expected).toFixed(1) + '%';
+                            }
+                            dev.textContent = sub;
                         }
                     }
 
@@ -1863,16 +1868,15 @@
                             document.getElementById('active-viewers-count').textContent = data.active_viewers;
                         }
 
-                        // Update Meter Reads (24h): fresh reads received vs expected over the last 24h
+                        // Update Meter Reads: fresh reads received vs expected over the last 24h
                         const readsEl = document.getElementById('meter-reads');
                         if (readsEl) {
                             const r = data.reads_24h;
                             if (r && r.expected) {
-                                readsEl.textContent =
-                                    `${r.received.toLocaleString()}/${r.expected.toLocaleString()}`;
+                                readsEl.textContent = `${r.received}/${r.expected}`;
                             } else if (data.packets_today !== undefined) {
                                 // Fallback until the backend reports reads_24h (e.g. DB unreachable)
-                                readsEl.textContent = data.packets_today.toLocaleString();
+                                readsEl.textContent = `${data.packets_today}`;
                             }
                         }
 


### PR DESCRIPTION
## What

Per request, three small dashboard tweaks (frontend only):

1. **Big "Data Uptime" tile** — append the Meter Reads completeness % after the device value in the sublabel: `device 100% · reads 99.7%`. Puts the honest fresh-read figure next to device health.
2. **Small tile label** — drop "(24h)": `Meter Reads (24h)` → `Meter Reads` (the tooltip still explains the 24h window).
3. **Small tile count** — remove thousands separators: `2,450/2,457` → `2450/2457`.

The value shown is `100 × reads_24h.received / reads_24h.expected`, already served by `/api/stats`; no backend or Pi change.

## Note

Merging deploys `fly/web`. Data Uptime's main value is left as-is per the instruction (only the device sublabel gains the reads %).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HiD4k8Y6XEjX8SFpNebRJ