### PR TITLE
ui(dashboard): Sample Interval shows measured cycle period (~35s), steady colour

### DIFF
--- a/fly/web/index.html
+++ b/fly/web/index.html
@@ -1226,7 +1226,7 @@
                             </div>
                         </div>
                         <div class="api-status-item">
-                            <span class="api-name">⏱️ Sample Interval</span>
+                            <span class="api-name" title="The Pi's measured read cycle: the ~30s wait plus the per-cycle work (~35s total). Green = normal cadence; yellow/red = cycles running long (e.g. the Eagle slow to answer).">⏱️ Sample Interval</span>
                             <div class="api-status">
                                 <span id="packet-interval" style="font-weight: 600; color: var(--text-primary);">--</span>
                             </div>
@@ -1880,19 +1880,22 @@
                             }
                         }
 
-                        // Update packet interval (time between Eagle-200 packets)
+                        // Sample interval = the Pi's measured read cycle (~35s: the ~30s
+                        // wait plus per-cycle work), reported via the heartbeat. Colour
+                        // reflects whether the cadence is normal or the Pi is running long
+                        // (e.g. the Eagle getting slow to answer), not the old per-message gap.
                         const intervalEl = document.getElementById('packet-interval');
-                        if (data.packet_interval_ms !== null && data.packet_interval_ms !== undefined) {
-                            const intervalSec = data.packet_interval_ms / 1000;
-                            if (intervalSec < 15) {
-                                intervalEl.textContent = intervalSec.toFixed(1) + 's';
-                                intervalEl.style.color = '#22c55e'; // green - normal ~8-10s
-                            } else if (intervalSec < 30) {
-                                intervalEl.textContent = intervalSec.toFixed(1) + 's';
-                                intervalEl.style.color = '#eab308'; // yellow - slightly delayed
+                        const bs = data.bypass_status || {};
+                        const periodS = bs.cycle_period_s;
+                        if (periodS !== null && periodS !== undefined) {
+                            const nominal = bs.interval_s || 30;
+                            intervalEl.textContent = periodS.toFixed(0) + 's';
+                            if (periodS <= nominal * 1.5) {
+                                intervalEl.style.color = '#22c55e';   // green - normal cadence
+                            } else if (periodS <= nominal * 2) {
+                                intervalEl.style.color = '#eab308';   // yellow - cycles running slow
                             } else {
-                                intervalEl.textContent = intervalSec.toFixed(0) + 's';
-                                intervalEl.style.color = '#ef4444'; // red - significant gap
+                                intervalEl.style.color = '#ef4444';   // red - cycles badly delayed
                             }
                         } else {
                             intervalEl.textContent = '--';


### PR DESCRIPTION
## What

Fix the "Sample Interval" tile, which flickered between ~0.6s and ~34s and between green and red.

## Why it was wrong

- **Value:** it read `packet_interval_ms` = the gap between the last two *messages*. The Pi sends three messages per cycle in a burst (~0.5s apart) then waits ~34s, so the "last-two gap" is sub-second 2/3 of the time and ~34s 1/3 of the time, depending on which message was last when the page polled. It was never the sample interval.
- **Colour:** thresholds (green <15s, yellow <30s, red ≥30s) were tuned for the Eagle's old ~8–10s native rate, so at our real ~35s cadence the between-cycle gap always flashed red and the burst gaps always green — pure noise.

## Fix

- Value now comes from `bypass_status.cycle_period_s` (the Pi's measured read cycle, ~35s), so it's steady.
- Colour is relative to the nominal interval: green ≤ 1.5×, yellow ≤ 2×, red beyond — i.e. it only warns when cycles genuinely run long (Eagle slow to answer), not on every healthy cycle.
- Added a tooltip explaining the value and colours.

Frontend only; `cycle_period_s` is already served by `/api/stats`. Renders as a steady **35s green** with current data. Merging deploys `fly/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HiD4k8Y6XEjX8SFpNebRJ